### PR TITLE
DS-3602 Handle inputs with zero dimensions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: verbs
 Type: Package
 Title: A Grammar for Common Data Manipulations and Summaries
-Version: 0.13.2
+Version: 0.13.4
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: A collection of operations/actions/"verbs" providing an intuitive interface for many common operations (e.g. Sum, First, Average, Maximum, ...) on various inputs/data structures. Created to simplify common user actions in Displayr with a wide variety of inputs.

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -62,11 +62,12 @@ processArgumentsForCounting <- function(x,
     x
 }
 
-#'
+
 #' @noRd
 commonPreProcessing <- function(x, function.name)
 {
     x <- Filter(Negate(is.null), x)
+    x <- Filter(function(x) prod(DIM(x)), x)
     if (length(x) == 0)
        return(list(NULL))
     x <- removeCharacterStatisticsFromQTables(x)

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -1455,6 +1455,12 @@ test_that("Handling of NULL elements is ok", {
                                   warn = FALSE,
                                   check.statistics = FALSE),
                  list(1, 2, 3, 4))
+    # No rows or columns
+    df <- data.frame(x = NULL, y = NULL, z = NULL)
+    expect_equal(processArguments(list(df)), list(NULL))
+    df <- structure(list(), .Names = character(0), class = "data.frame",
+                    row.names = c(NA, 4386L))
+    expect_equal(processArguments(list(df)), list(NULL))
 })
 
 test_that("Check multiple statistics", {


### PR DESCRIPTION
Catch inputs that have zero rows or zero columns due to a filter being
applied before it reaches verbs.
