### PR TITLE
DS-3806 Subscript span attr for 1d and 2d tables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: verbs
 Type: Package
 Title: A Grammar for Common Data Manipulations and Summaries
-Version: 0.14.1
+Version: 0.14.2
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: A collection of operations/actions/"verbs" providing an intuitive interface for many common operations (e.g. Sum, First, Average, Maximum, ...) on various inputs/data structures. Created to simplify common user actions in Displayr with a wide variety of inputs.

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -166,8 +166,9 @@ updateSpanIfNecessary <- function(y, x.attributes, called.args, evaluated.args) 
     if (is.null(span.attribute)) return(y)
     single.dim <- length(x.attributes[["dim"]]) == 1L
     if (single.dim) {
-        new.span.df <- do.call("[", list(span.attribute[["rows"]], called.args[[1L]], alist(, )[[1L]]))
-        attr(y, "span") <- list(rows = new.span.df)
+        new.span.df <- do.call("[", list(span.attribute[["rows"]], evaluated.args[[1L]], alist(, )[[1L]]))
+        if (!all(is.na(new.span.df[, 1])))
+            attr(y, "span") <- list(rows = new.span.df)
     }
     y
 }

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -161,14 +161,21 @@ updateTableAttributes <- function(y, x, called.args, evaluated.args) {
     y
 }
 
+subscriptSpanDF <- function(span.attr, idx) {
+    out <- span.attr[idx, , drop = FALSE]
+    if (all(is.na(out[, 1L]))) invisible() else out
+}
+
 updateSpanIfNecessary <- function(y, x.attributes, called.args, evaluated.args) {
     span.attribute <- x.attributes[["span"]]
     if (is.null(span.attribute)) return(y)
-    single.dim <- length(x.attributes[["dim"]]) == 1L
-    if (single.dim) {
-        new.span.df <- do.call("[", list(span.attribute[["rows"]], evaluated.args[[1L]], alist(, )[[1L]]))
-        if (!all(is.na(new.span.df[, 1])))
-            attr(y, "span") <- list(rows = new.span.df)
-    }
+    dim.length <- length(x.attributes[["dim"]])
+    if (dim.length > 1L && length(evaluated.args) == 1L) return(y)
+    if (dim.length > 2L)
+        evaluated.args <- evaluated.args[1:2]
+    span.df <- mapply(subscriptSpanDF, span.attribute, evaluated.args, SIMPLIFY = FALSE)
+    span.df <- Filter(Negate(is.null), span.df)
+    if (length(span.df))
+        attr(y, "span") <- span.df
     y
 }

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -164,10 +164,10 @@ updateTableAttributes <- function(y, x, called.args, evaluated.args) {
 
 subscriptSpanDF <- function(span.attr, idx) {
     if (NCOL(span.attr) == 1L) return(invisible())
+    if (isEmptyArg(idx)) return(span.attr)
     if (is.character(idx))
         idx <- which(span.attr[[2]] %in% idx)
-    if (isEmptyArg(idx)) return(span.attr)
-    out <- span.attr[if (!all(idx == idx[1L])) idx else idx[1L], , drop = FALSE]
+    out <- span.attr[idx, , drop = FALSE]
     if (all(is.na(out[[1L]]))) invisible() else out
 }
 

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -68,6 +68,7 @@ providedArgumentEmpty <- function(called.args, optional.arg) {
     named.args[3L] == optional.arg || isEmptyList(called.args[3L])
 }
 
+isEmptyArg <- function(x) length(x) == 1L && x == alist(, )[1L][[1L]]
 isEmptyList <- function(x) x == quote(as.pairlist(alist())())
 
 generalInvalidSubscriptMsg <- function(x.name) {
@@ -165,16 +166,36 @@ subscriptSpanDF <- function(span.attr, idx) {
     if (NCOL(span.attr) == 1L) return(invisible())
     if (is.character(idx))
         idx <- which(span.attr[[2]] %in% idx)
-    out <- span.attr[idx, , drop = FALSE]
+    if (isEmptyArg(idx)) return(span.attr)
+    out <- span.attr[if (!all(idx == idx[1L])) idx else idx[1L], , drop = FALSE]
     if (all(is.na(out[[1L]]))) invisible() else out
 }
 
 updateSpanIfNecessary <- function(y, x.attributes, evaluated.args) {
     span.attribute <- x.attributes[["span"]]
     if (is.null(span.attribute)) return(y)
-    dim.length <- length(x.attributes[["dim"]])
-    if (dim.length > 1L && length(evaluated.args) == 1L) return(y)
-    if (dim.length > 2L)
+    x.dim <- x.attributes[["dim"]]
+    dim.length <- length(x.dim)
+    # Span will be dropped if an integer vector is used on an array with more than 1 dimension
+    # unless the integer vector sweeps out an entire dimension. Start by converting to array index matrix
+    if (dim.length > 1L && length(evaluated.args) == 1L) {
+        # Boolean check, if boolean index is not the same, don't return span,
+        # otherwise coerce to array index reference matrix
+        args <- evaluated.args[[1L]]
+        if (is.logical(evaluated.args[[1L]])) {
+            if (!identical(dim(evaluated.args[[1L]]), x.dim)) return(y)
+            evaluated.args[[1L]] <- which(args, arr.ind = TRUE)
+        }
+        if (is.numeric(evaluated.args[[1L]]) && !is.matrix(evaluated.args[[1L]]))
+            evaluated.args[[1L]] <- arrayInd(evaluated.args[[1L]], x.dim)
+        # From here, the args will be an integer matrix with at least 2 columns (truncate to 2 columns if more)
+        unique.vals.per.dim <- lengths(apply(evaluated.args[[1]][, 1:2, drop = FALSE], 2L, unique))
+        # Only retain the span if the referenced cells span an entire dimension (row or column)
+        if (!any(unique.vals.per.dim == 1L))
+            return(y)
+        evaluated.args <- split(evaluated.args[[1L]], col(evaluated.args[[1L]]))
+    }
+    if (dim.length > 2L && length(evaluated.args) > 2L)
         evaluated.args <- evaluated.args[1:2]
     span.df <- mapply(subscriptSpanDF, span.attribute, evaluated.args, SIMPLIFY = FALSE)
     span.df <- Filter(Negate(is.null), span.df)

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -176,8 +176,8 @@ updateSpanIfNecessary <- function(y, x.attributes, evaluated.args) {
     if (is.null(span.attribute)) return(y)
     x.dim <- x.attributes[["dim"]]
     dim.length <- length(x.dim)
-    # Span will be dropped if an integer vector is used on an array with more than 1 dimension
-    # unless the integer vector sweeps out an entire dimension. Start by converting to array index matrix
+    # Span will be dropped if single indexing argument (vector or matrix etc) used on an array
+    # with more than 1 dimension. The dimension isn't retained on base R here and the spans lose utility
     if (dim.length > 1L && length(evaluated.args) == 1L) return(y)
     if (dim.length > 2L && length(evaluated.args) > 2L)
         evaluated.args <- evaluated.args[1:2]

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -162,6 +162,7 @@ updateTableAttributes <- function(y, x, called.args, evaluated.args) {
 }
 
 subscriptSpanDF <- function(span.attr, idx) {
+    if (NCOL(span.attr) == 1L) return(invisible())
     if (is.character(idx))
         idx <- which(span.attr[[2]] %in% idx)
     out <- span.attr[idx, , drop = FALSE]

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -165,7 +165,7 @@ subscriptSpanDF <- function(span.attr, idx) {
     if (is.character(idx))
         idx <- which(span.attr[[2]] %in% idx)
     out <- span.attr[idx, , drop = FALSE]
-    if (all(is.na(out[, 1L]))) invisible() else out
+    if (all(is.na(out[[1L]]))) invisible() else out
 }
 
 updateSpanIfNecessary <- function(y, x.attributes, called.args, evaluated.args) {

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -178,23 +178,7 @@ updateSpanIfNecessary <- function(y, x.attributes, evaluated.args) {
     dim.length <- length(x.dim)
     # Span will be dropped if an integer vector is used on an array with more than 1 dimension
     # unless the integer vector sweeps out an entire dimension. Start by converting to array index matrix
-    if (dim.length > 1L && length(evaluated.args) == 1L) {
-        # Boolean check, if boolean index is not the same, don't return span,
-        # otherwise coerce to array index reference matrix
-        args <- evaluated.args[[1L]]
-        if (is.logical(evaluated.args[[1L]])) {
-            if (!identical(dim(evaluated.args[[1L]]), x.dim)) return(y)
-            evaluated.args[[1L]] <- which(args, arr.ind = TRUE)
-        }
-        if (is.numeric(evaluated.args[[1L]]) && !is.matrix(evaluated.args[[1L]]))
-            evaluated.args[[1L]] <- arrayInd(evaluated.args[[1L]], x.dim)
-        # From here, the args will be an integer matrix with at least 2 columns (truncate to 2 columns if more)
-        unique.vals.per.dim <- lengths(apply(evaluated.args[[1]][, 1:2, drop = FALSE], 2L, unique))
-        # Only retain the span if the referenced cells span an entire dimension (row or column)
-        if (!any(unique.vals.per.dim == 1L))
-            return(y)
-        evaluated.args <- split(evaluated.args[[1L]], col(evaluated.args[[1L]]))
-    }
+    if (dim.length > 1L && length(evaluated.args) == 1L) return(y)
     if (dim.length > 2L && length(evaluated.args) > 2L)
         evaluated.args <- evaluated.args[1:2]
     span.df <- mapply(subscriptSpanDF, span.attribute, evaluated.args, SIMPLIFY = FALSE)

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -17,7 +17,7 @@
     # Throw a nicer error if the indexing is not appropriate
     if (n.index.args != 1 && n.dim != n.index.args)
         throwErrorTableIndexInvalid(input.name, x.dim)
-    y <- NextMethod(x)
+    y <- NextMethod(`[`)
     called.args <- as.list(called.args[["..."]])
 
     ## Need to evaluate the arguments here to alleviate possible NSE issues; c.f.:
@@ -162,6 +162,8 @@ updateTableAttributes <- function(y, x, called.args, evaluated.args) {
 }
 
 subscriptSpanDF <- function(span.attr, idx) {
+    if (is.character(idx))
+        idx <- which(span.attr[[2]] %in% idx)
     out <- span.attr[idx, , drop = FALSE]
     if (all(is.na(out[, 1L]))) invisible() else out
 }

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -163,10 +163,9 @@ updateTableAttributes <- function(y, x, called.args, evaluated.args) {
 }
 
 subscriptSpanDF <- function(span.attr, idx) {
-    if (NCOL(span.attr) == 1L) return(invisible())
     if (isEmptyArg(idx)) return(span.attr)
     if (is.character(idx))
-        idx <- which(span.attr[[2]] %in% idx)
+        idx <- which(span.attr[[NCOL(span.attr)]] %in% idx)
     out <- span.attr[idx, , drop = FALSE]
     if (all(is.na(out[[1L]]))) invisible() else out
 }

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -155,7 +155,7 @@ updateTableAttributes <- function(y, x, called.args, evaluated.args) {
     attr.names <- names(attributes(y))
     names.needing.update <- !isBasicAttribute(attr.names)
     names(attributes(y))[names.needing.update] <- paste0("original.", attr.names[names.needing.update])
-    y <- updateSpanIfNecessary(y, x.attributes, called.args, evaluated.args)
+    y <- updateSpanIfNecessary(y, x.attributes, evaluated.args)
     attr(y, "name") <- paste0(x.attributes[["name"]], "[",
                               paste(as.character(called.args), collapse = ","), "]")
     y
@@ -168,7 +168,7 @@ subscriptSpanDF <- function(span.attr, idx) {
     if (all(is.na(out[[1L]]))) invisible() else out
 }
 
-updateSpanIfNecessary <- function(y, x.attributes, called.args, evaluated.args) {
+updateSpanIfNecessary <- function(y, x.attributes, evaluated.args) {
     span.attribute <- x.attributes[["span"]]
     if (is.null(span.attribute)) return(y)
     dim.length <- length(x.attributes[["dim"]])

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -147,7 +147,19 @@ updateTableAttributes <- function(y, x, called.args) {
     attr.names <- names(attributes(y))
     names.needing.update <- !isBasicAttribute(attr.names)
     names(attributes(y))[names.needing.update] <- paste0("original.", attr.names[names.needing.update])
+    y <- updateSpanIfNecessary(y, x.attributes, called.args)
     attr(y, "name") <- paste0(x.attributes[["name"]], "[",
                               paste(as.character(called.args), collapse = ","), "]")
+    y
+}
+
+updateSpanIfNecessary <- function(y, x.attributes, called.args) {
+    span.attribute <- x.attributes[["span"]]
+    if (is.null(span.attribute)) return(y)
+    single.dim <- length(x.attributes[["dim"]]) == 1L
+    if (single.dim) {
+        new.span.df <- do.call("[", list(span.attribute[["rows"]], called.args[[1L]], alist(, )[[1L]]))
+        attr(y, "span") <- list(rows = new.span.df)
+    }
     y
 }

--- a/tests/testthat/test-subscript-tables.R
+++ b/tests/testthat/test-subscript-tables.R
@@ -253,18 +253,23 @@ test_that("Span attributes retained properly", {
     attr(age.table, "span") <- list(rows = age.span)
     class(age.table) <- c("qTable", class(age.table))
     checkSpanAttribute(age.table[1:2], list(rows = age.span[1:2, ]))
+    checkSpanAttribute(age.table[c("15-18", "19 to 24")], list(rows = age.span[1:2, ]))
     checkSpanAttribute(age.table[2:3], list(rows = age.span[2:3, ]))
+    checkSpanAttribute(age.table[c("19 to 24", "25 to 29")], list(rows = age.span[2:3, ]))
     checkSpanAttribute(age.table[c(1, 3)], list(rows = age.span[c(1, 3), ]))
+    checkSpanAttribute(age.table[c("15-18", "25 to 29")], list(rows = age.span[c(1, 3), ]))
     checkSpanAttribute(age.table[c(1, 7)], list(rows = age.span[c(1, 7), ]))
+    checkSpanAttribute(age.table[c("15-18", "45 to 49")], list(rows = age.span[c(1, 7), ]))
     # Drop the span if it is not there (all NA)
     checkSpanAttribute(age.table[6:7], NULL)
+    checkSpanAttribute(age.table[c("40 to 44", "45 to 49")], NULL)
     ###########
     # 2d case #
     ###########
     dims <- 6:7
     values <- round(runif(prod(dims)), 2)
     dimnames.2d <- list(c("Coca Cola", "Diet Coke", "Coke Zero", "Pepsi", "Pepsi Light", "Pepsi Max"),
-                        c("Don't Know", "Hate", "Disklike", "Neither", "Like", "Love", "NET"))
+                        c("Don't know", "Hate", "Dislike", "Neither", "Like", "Love", "NET"))
     table.2d <- array(values, dim = 6:7, dimnames = dimnames.2d)
     span.2d <- list(rows = data.frame(c("Cokes", "Cokes", "Cokes", "Standard Pepsi", NA, "Standard Pepsi"),
                                       dimnames.2d[[1L]],
@@ -282,33 +287,42 @@ test_that("Span attributes retained properly", {
     expected.span <- span.2d
     expected.span[[1L]] <- expected.span[[1L]][1:2, ]
     checkSpanAttribute(table.2d[1:2, ], expected.span)
+    checkSpanAttribute(table.2d[c("Coca Cola", "Diet Coke"), ], expected.span)
     expected.span <- span.2d
     expected.span[[1L]] <- expected.span[[1L]][1:4, ]
     checkSpanAttribute(table.2d[1:4, ], expected.span)
+    checkSpanAttribute(table.2d[c("Coca Cola", "Diet Coke", "Coke Zero", "Pepsi"), ], expected.span)
     expected.span <- span.2d
     expected.span[[1L]] <- expected.span[[1L]][3:5, ]
     checkSpanAttribute(table.2d[3:5, ], expected.span)
+    checkSpanAttribute(table.2d[c("Coke Zero", "Pepsi", "Pepsi Light"), ], expected.span)
     ### Span dropped if there is none
     expected.span <- span.2d[2]
     checkSpanAttribute(table.2d[5, ], expected.span)
+    checkSpanAttribute(table.2d["Pepsi Light", ], expected.span)
     ## Column checks
     ### Column span dropped but rows remain
     expected.span <- span.2d[1]
     checkSpanAttribute(table.2d[, c(1, 4)], expected.span)
+    checkSpanAttribute(table.2d[, c("Don't know", "Neither")], expected.span)
     ### Column spans found appropriately
     expected.span <- span.2d
     expected.span[[2]] <- span.2d[[2]][c(1, 3, 5), ]
     checkSpanAttribute(table.2d[, c(1, 3, 5)], expected.span)
+    checkSpanAttribute(table.2d[, c("Don't know", "Dislike", "Like")], expected.span)
     ## Row and Column checks
     expected.span <- span.2d
     expected.span[[1L]] <- span.2d[[1]][1:3, , drop = FALSE]
     expected.span[[2L]] <- span.2d[[2]][1:3, , drop = FALSE]
     checkSpanAttribute(table.2d[1:3, 1:3], expected.span)
+    checkSpanAttribute(table.2d[c("Coca Cola", "Diet Coke", "Coke Zero"),
+                                c("Don't know", "Hate", "Dislike")], expected.span)
     ### No span remains if all NA
-    checkAttribute(table.2d[5, c(1, 4)], "span", NULL)
+    checkSpanAttribute(table.2d[5, c(1, 4)], NULL)
+    checkSpanAttribute(table.2d["Pepsi Light", c("Don't know", "Neither")], NULL)
     # 2d table with multiple statistics (3d array)
     table.3d <- array(rep(as.vector(table.2d), 2L), dim = c(dim(table.2d), 2L),
-                      dimnames = c(dimnames(table.2d), list(c("row %", "exepected %"))))
+                      dimnames = c(dimnames(table.2d), list(c("Row %", "Expected %"))))
     attr(table.3d, "span") <- span.2d
     class(table.3d) <- c("qTable", class(table.3d))
     ### Both rows and columns ok
@@ -316,12 +330,17 @@ test_that("Span attributes retained properly", {
     expected.span[[1]] <- span.2d[[1]][1:2, , drop = FALSE]
     expected.span[[2]] <- span.2d[[2]][1:2, , drop = FALSE]
     checkSpanAttribute(table.3d[1:2, 1:2, ], expected.span)
+    checkSpanAttribute(table.3d[c("Coca Cola", "Diet Coke"), c("Don't know", "Hate"), ], expected.span)
     ### Span dropped if not required
     expected.span <- span.2d[2]
     expected.span[[1]] <- span.2d[[2]][c(2, 4, 6), , drop = FALSE]
     checkSpanAttribute(table.3d[5, c(2, 4, 6), ], expected.span)
+    checkSpanAttribute(table.3d["Pepsi Light", c("Hate", "Neither", "Love"), ], expected.span)
     ### Isn't affected by stat selection
     checkSpanAttribute(table.3d[5, c(2, 4, 6), 1], expected.span)
+    checkSpanAttribute(table.3d["Pepsi Light", c("Hate", "Neither", "Love"), "Row %"], expected.span)
     checkSpanAttribute(table.3d[5, c(2, 4, 6), 2], expected.span)
-    checkSpanAttribute(table.3d[5, c(2, 4, 6), 1:2], expected.span)
+    checkSpanAttribute(table.3d["Pepsi Light", c("Hate", "Neither", "Love"), "Expected %"], expected.span)
+    checkSpanAttribute(table.3d[5, c(2, 4, 6), ], expected.span)
+    checkSpanAttribute(table.3d["Pepsi Light", c("Hate", "Neither", "Love"), ], expected.span)
 })

--- a/tests/testthat/test-subscript-tables.R
+++ b/tests/testthat/test-subscript-tables.R
@@ -241,12 +241,55 @@ checkAttribute <- function(x, attr.name, desired.attr) {
 
 test_that("Span attributes retained properly", {
     checkSpanAttribute <- function(input, expected.attr) checkAttribute(input, "span", expected.attr)
-    ###########
-    # 1d case #
-    ###########
+    ############
+    # No spans #
+    ############
+    ## 1d case #
+    ############
     values <- c(9.91, 17.39, 11, 14.63, 16.01, 17.06, 13.99, 100)
     value.names <- c("15-18", "19 to 24", "25 to 29", "30 to 34", "35 to 39", "40 to 44", "45 to 49", "NET")
     age.table <- array(values, dim = length(values), dimnames = list(value.names))
+    class(age.table) <- c("qTable", class(age.table))
+    checkSpanAttribute(age.table[1:2], NULL)
+    checkSpanAttribute(age.table[c("19 to 24", "45 to 49")], NULL)
+    empty.span <- data.frame(value.names, fix.empty.names = FALSE)
+    attr(age.table, "span") <- empty.span
+    checkSpanAttribute(age.table[1:2], NULL)
+    checkSpanAttribute(age.table[c("19 to 24", "45 to 49")], NULL)
+    ############
+    ## 2d case #
+    ############
+    dims <- 6:7
+    values <- round(runif(prod(dims)), 2)
+    dimnames.2d <- list(c("Coca Cola", "Diet Coke", "Coke Zero", "Pepsi", "Pepsi Light", "Pepsi Max"),
+                        c("Don't know", "Hate", "Dislike", "Neither", "Like", "Love", "NET"))
+    table.2d <- array(values, dim = 6:7, dimnames = dimnames.2d)
+    span.2d <- list(rows = data.frame(c("Cokes", "Cokes", "Cokes", "Standard Pepsi", NA, "Standard Pepsi"),
+                                      dimnames.2d[[1L]],
+                                      fix.empty.names = FALSE),
+                    columns = data.frame(c(NA, "Don't like", "Don't like", NA, "Like", "Like", NA),
+                                         dimnames.2d[[2L]],
+                                         fix.empty.names = FALSE))
+    empty.span <- list(rows = data.frame(rownames(table.2d), fix.empty.names = FALSE),
+                       columns = data.frame(colnames(table.2d), fix.empty.names = FALSE))
+    class(table.2d) <- c("qTable", class(table.2d))
+    checkSpanAttribute(table.2d[1:2, 3:4], NULL)
+    attr(age.table, "span") <- empty.span
+    checkSpanAttribute(table.2d[1:2, 3:4], NULL)
+    ############
+    ## 3d case #
+    ############
+    table.3d <- array(rep(as.vector(table.2d), 2L), dim = c(dim(table.2d), 2L),
+                      dimnames = c(dimnames(table.2d), list(c("Row %", "Expected %"))))
+    class(table.3d) <- c("qTable", class(table.3d))
+    checkSpanAttribute(table.3d[1:6, , ], NULL)
+    empty.span <- list(rows = data.frame(rownames(table.3d), fix.empty.names = FALSE),
+                       columns = data.frame(colnames(table.3d), fix.empty.names = FALSE))
+    attr(table.3d, "span") <- empty.span
+    checkSpanAttribute(table.3d[1:6, , ], NULL)
+    ###################
+    # General 1d case #
+    ###################
     age.span <- data.frame(c("&lt;25", "&lt;25", "25-39", "25-39", "25-39", NA, NA, NA),
                            value.names,
                            fix.empty.names = FALSE)

--- a/tests/testthat/test-subscript-tables.R
+++ b/tests/testthat/test-subscript-tables.R
@@ -252,16 +252,12 @@ test_that("Span attributes retained properly", {
                            fix.empty.names = FALSE)
     attr(age.table, "span") <- list(rows = age.span)
     class(age.table) <- c("qTable", class(age.table))
-    checkAttribute(age.table[1:2], "span",
-                   list(rows = age.span[1:2, ]))
-    checkAttribute(age.table[2:3], "span",
-                   list(rows = age.span[2:3, ]))
-    checkAttribute(age.table[c(1, 3)], "span",
-                   list(rows = age.span[c(1, 3), ]))
-    checkAttribute(age.table[c(1, 7)], "span",
-                   list(rows = age.span[c(1, 7), ]))
+    checkSpanAttribute(age.table[1:2], list(rows = age.span[1:2, ]))
+    checkSpanAttribute(age.table[2:3], list(rows = age.span[2:3, ]))
+    checkSpanAttribute(age.table[c(1, 3)], list(rows = age.span[c(1, 3), ]))
+    checkSpanAttribute(age.table[c(1, 7)], list(rows = age.span[c(1, 7), ]))
     # Drop the span if it is not there (all NA)
-    checkAttribute(age.table[6:7], "span", NULL)
+    checkSpanAttribute(age.table[6:7], NULL)
     ###########
     # 2d case #
     ###########
@@ -285,29 +281,29 @@ test_that("Span attributes retained properly", {
     ### Subscripting only rows with a span, all columns included
     expected.span <- span.2d
     expected.span[[1L]] <- expected.span[[1L]][1:2, ]
-    checkAttribute(table.2d[1:2, ], "span", expected.span)
+    checkSpanAttribute(table.2d[1:2, ], expected.span)
     expected.span <- span.2d
     expected.span[[1L]] <- expected.span[[1L]][1:4, ]
-    checkAttribute(table.2d[1:4, ], "span", expected.span)
+    checkSpanAttribute(table.2d[1:4, ], expected.span)
     expected.span <- span.2d
     expected.span[[1L]] <- expected.span[[1L]][3:5, ]
-    checkAttribute(table.2d[3:5, ], "span", expected.span)
+    checkSpanAttribute(table.2d[3:5, ], expected.span)
     ### Span dropped if there is none
     expected.span <- span.2d[2]
-    checkAttribute(table.2d[5, ], "span", expected.span)
+    checkSpanAttribute(table.2d[5, ], expected.span)
     ## Column checks
     ### Column span dropped but rows remain
     expected.span <- span.2d[1]
-    checkAttribute(table.2d[, c(1, 4)], "span", expected.span)
+    checkSpanAttribute(table.2d[, c(1, 4)], expected.span)
     ### Column spans found appropriately
     expected.span <- span.2d
     expected.span[[2]] <- span.2d[[2]][c(1, 3, 5), ]
-    checkAttribute(table.2d[, c(1, 3, 5)], "span", expected.span)
+    checkSpanAttribute(table.2d[, c(1, 3, 5)], expected.span)
     ## Row and Column checks
     expected.span <- span.2d
     expected.span[[1L]] <- span.2d[[1]][1:3, , drop = FALSE]
     expected.span[[2L]] <- span.2d[[2]][1:3, , drop = FALSE]
-    checkAttribute(table.2d[1:3, 1:3], "span", expected.span)
+    checkSpanAttribute(table.2d[1:3, 1:3], expected.span)
     ### No span remains if all NA
     checkAttribute(table.2d[5, c(1, 4)], "span", NULL)
     # 2d table with multiple statistics (3d array)
@@ -319,13 +315,13 @@ test_that("Span attributes retained properly", {
     expected.span <- span.2d
     expected.span[[1]] <- span.2d[[1]][1:2, , drop = FALSE]
     expected.span[[2]] <- span.2d[[2]][1:2, , drop = FALSE]
-    checkAttribute(table.3d[1:2, 1:2, ], "span", expected.span)
+    checkSpanAttribute(table.3d[1:2, 1:2, ], expected.span)
     ### Span dropped if not required
     expected.span <- span.2d[2]
     expected.span[[1]] <- span.2d[[2]][c(2, 4, 6), , drop = FALSE]
-    checkAttribute(table.3d[5, c(2, 4, 6), ], "span", expected.span)
+    checkSpanAttribute(table.3d[5, c(2, 4, 6), ], expected.span)
     ### Isn't affected by stat selection
-    checkAttribute(table.3d[5, c(2, 4, 6), 1], "span", expected.span)
-    checkAttribute(table.3d[5, c(2, 4, 6), 2], "span", expected.span)
-    checkAttribute(table.3d[5, c(2, 4, 6), 1:2], "span", expected.span)
+    checkSpanAttribute(table.3d[5, c(2, 4, 6), 1], expected.span)
+    checkSpanAttribute(table.3d[5, c(2, 4, 6), 2], expected.span)
+    checkSpanAttribute(table.3d[5, c(2, 4, 6), 1:2], expected.span)
 })

--- a/tests/testthat/test-subscript-tables.R
+++ b/tests/testthat/test-subscript-tables.R
@@ -57,17 +57,9 @@ test_that("Empty indices handled appropriately", {
     }
 })
 
-silentDput <- function(x) {
-    if (is.symbol(x)) return(x)
-    sink(tempfile())
-    y <- dput(x)
-    sink()
-    y
-}
-
 singleSubscriptTable <- function(tab, ind, drop = NULL) {
     n.ind <- length(ind)
-    args <- c(list(tab), lapply(ind, silentDput))
+    args <- c(list(tab), ind)
     if (!is.null(drop)) args <- c(args, drop = drop)
     do.call(`[`, args)
 }
@@ -81,7 +73,7 @@ expectedSingleTable <- function(tab, ind, drop = NULL) {
 }
 doubleSubscriptTable <- function(tab, ind, exact = NULL) {
     n.ind <- length(ind)
-    args <- c(list(tab), lapply(ind, silentDput))
+    args <- c(list(tab), ind)
     if (!is.null(exact)) args <- c(args, exact = exact)
     do.call(`[[`, args)
 }

--- a/tests/testthat/test-subscript-tables.R
+++ b/tests/testthat/test-subscript-tables.R
@@ -58,7 +58,6 @@ test_that("Empty indices handled appropriately", {
 })
 
 singleSubscriptTable <- function(tab, ind, drop = NULL) {
-    n.ind <- length(ind)
     args <- c(list(tab), ind)
     if (!is.null(drop)) args <- c(args, drop = drop)
     do.call(`[`, args)
@@ -72,7 +71,6 @@ expectedSingleTable <- function(tab, ind, drop = NULL) {
     y
 }
 doubleSubscriptTable <- function(tab, ind, exact = NULL) {
-    n.ind <- length(ind)
     args <- c(list(tab), ind)
     if (!is.null(exact)) args <- c(args, exact = exact)
     do.call(`[[`, args)
@@ -253,16 +251,19 @@ test_that("Span attributes retained properly", {
     checkSpanAttribute(age.table[1:2], NULL)
     checkSpanAttribute(age.table[c("19 to 24", "45 to 49")], NULL)
     checkSpanAttribute(age.table[as.logical(rep(c(1L, 0L), c(2L, 4L)))], NULL)
-    empty.span <- data.frame(value.names, fix.empty.names = FALSE)
+    empty.span <- list(rows = data.frame(value.names, fix.empty.names = FALSE))
     attr(age.table, "span") <- empty.span
-    checkSpanAttribute(age.table[1:2], NULL)
-    checkSpanAttribute(age.table[c("19 to 24", "45 to 49")], NULL)
+    expected.empty <- empty.span
+    expected.empty[[1]] <- empty.span[[1]][1:2, , drop = FALSE]
+    checkSpanAttribute(age.table[1:2], expected.empty)
     logical.age.table <- array(FALSE, dim = dim(age.table))
     age.table.logical <- logical.age.table
     age.table.logical[1:2] <- TRUE
-    checkSpanAttribute(age.table[age.table.logical], NULL)
+    checkSpanAttribute(age.table[age.table.logical], expected.empty)
     int.mat.age.table <- which(age.table.logical, arr.ind = TRUE)
-    checkSpanAttribute(age.table[int.mat.age.table], NULL)
+    checkSpanAttribute(age.table[int.mat.age.table], expected.empty)
+    expected.empty[[1]] <- empty.span[[1]][c(2, 7), , drop = FALSE]
+    checkSpanAttribute(age.table[c("19 to 24", "45 to 49")], expected.empty)
     ############
     ## 2d case #
     ############
@@ -282,8 +283,11 @@ test_that("Span attributes retained properly", {
     logical.2d.mat <- array(FALSE, dim = dim(table.2d))
     class(table.2d) <- c("qTable", class(table.2d))
     checkSpanAttribute(table.2d[1:2, 3:4], NULL)
-    attr(age.table, "span") <- empty.span
-    checkSpanAttribute(table.2d[1:2, 3:4], NULL)
+    attr(table.2d, "span") <- empty.span
+    expected.span <- empty.span
+    expected.span[[1L]] <- empty.span[[1L]][1:2, , drop = FALSE]
+    expected.span[[2L]] <- empty.span[[2L]][3:4, , drop = FALSE]
+    checkSpanAttribute(table.2d[1:2, 3:4], expected.span)
     table.2d.logical <- logical.2d.mat
     table.2d.logical[1:2, 3:4] <- TRUE
     checkSpanAttribute(table.2d[table.2d.logical], NULL)
@@ -295,15 +299,17 @@ test_that("Span attributes retained properly", {
     table.3d <- array(rep(as.vector(table.2d), 2L), dim = c(dim(table.2d), 2L),
                       dimnames = c(dimnames(table.2d), list(c("Row %", "Expected %"))))
     class(table.3d) <- c("qTable", class(table.3d))
-    checkSpanAttribute(table.3d[1:6, , ], NULL)
+    checkSpanAttribute(table.3d[2:3, 3:4 , ], NULL)
     empty.span <- list(rows = data.frame(rownames(table.3d), fix.empty.names = FALSE),
                        columns = data.frame(colnames(table.3d), fix.empty.names = FALSE))
     attr(table.3d, "span") <- empty.span
-    checkSpanAttribute(table.3d[1:6, , ], NULL)
+    expected.span <- empty.span
+    expected.span[[1L]] <- empty.span[[1L]][2:3, , drop = FALSE]
+    expected.span[[2L]] <- empty.span[[2L]][3:4, , drop = FALSE]
+    checkSpanAttribute(table.3d[2:3, 3:4, ], expected.span)
     table.3d.logical <- array(FALSE, dim = dim(table.3d))
     table.3d.mat <- table.3d.logical
-    table.3d.mat[1:6, , ] <- TRUE
-    checkSpanAttribute(table.3d[1:6, , ], NULL)
+    table.3d.mat[2:3, 3:4, ] <- TRUE
     checkSpanAttribute(table.3d[table.3d.mat], NULL)
     int.mat.3d <- which(table.3d.mat, arr.ind = TRUE)
     checkSpanAttribute(table.3d[int.mat.3d], NULL)

--- a/tests/testthat/test-subscript-tables.R
+++ b/tests/testthat/test-subscript-tables.R
@@ -294,7 +294,6 @@ test_that("Span attributes retained properly", {
                            value.names,
                            fix.empty.names = FALSE)
     attr(age.table, "span") <- list(rows = age.span)
-    class(age.table) <- c("qTable", class(age.table))
     checkSpanAttribute(age.table[1:2], list(rows = age.span[1:2, ]))
     checkSpanAttribute(age.table[c("15-18", "19 to 24")], list(rows = age.span[1:2, ]))
     checkSpanAttribute(age.table[2:3], list(rows = age.span[2:3, ]))
@@ -323,8 +322,19 @@ test_that("Span attributes retained properly", {
     attr(table.2d, "span") <- span.2d
     attr(table.2d, "statistic") <- "Row %"
     class(table.2d) <- c("qTable", class(table.2d))
-    checkAttribute(table.2d[1:2], "span", NULL)
-    checkAttribute(table.2d[c(1, 3, 5, 7, 12)], "span", NULL)
+    ## Cell reference checks
+    ### All in first column
+    expected.span <- span.2d
+    expected.span[[1L]] <- span.2d[[1L]][1:2, ]
+    expected.span[[2L]] <- NULL
+    checkSpanAttribute(table.2d[1:2], expected.span)
+    ### All in 3rd column
+    expected.span <- span.2d
+    expected.span[[1L]] <- span.2d[[1L]][1:6, ]
+    expected.span[[2L]] <- span.2d[[2L]][3, ]
+    checkSpanAttribute(table.2d[6 * 2 + 1:6], expected.span)
+    ### Don't return span attribute if cell references are not a slice of the array
+    checkSpanAttribute(table.2d[c(1, 3, 5, 7, 12)], NULL)
     ## Row checks
     ### Subscripting only rows with a span, all columns included
     expected.span <- span.2d

--- a/tests/testthat/test-subscript-tables.R
+++ b/tests/testthat/test-subscript-tables.R
@@ -229,6 +229,10 @@ test_that("drop and exact recognised and used appropriately", {
 })
 
 checkAttribute <- function(x, attr.name, desired.attr) {
+    if (is.null(desired.attr)) {
+        expect_null(attr(x, attr.name))
+        return(invisible())
+    }
     x.attributes <- attributes(x)
     expect_true(attr.name %in% names(x.attributes))
     x.attr <- attr(x, attr.name)
@@ -236,36 +240,22 @@ checkAttribute <- function(x, attr.name, desired.attr) {
 }
 
 test_that("Span attributes retained properly", {
-    agespans <- structure(c(`15-18` = 9.91139501339378, `19 to 24` = 17.3913043478261,
-`25 to 29` = 11.0035029878426, `30 to 34` = 14.6301256954461,
-`35 to 39` = 16.0107150216361, `40 to 44` = 17.0616113744076,
-`45 to 49` = 13.9913455594478, NET = 100), dim = 8L, dimnames = list(
-    c("15-18", "19 to 24", "25 to 29", "30 to 34", "35 to 39",
-    "40 to 44", "45 to 49", "NET")), statistic = "%", span = list(
-    rows = structure(list(c("&lt;25", "&lt;25", "25-39", "25-39",
-    "25-39", NA, NA, NA), c("15-18", "19 to 24", "25 to 29",
-    "30 to 34", "35 to 39", "40 to 44", "45 to 49", "NET")), class = "data.frame", names = c("",
-    ""), row.names = c(NA, 8L))), basedescriptiontext = "sample size = 4853", basedescription = list(
-    Minimum = 4853L, Maximum = 4853L, Range = FALSE, Total = 4853L,
-    Missing = 0L, EffectiveSampleSize = 4853L, EffectiveSampleSizeProportion = 100,
-    FilteredProportion = 0), QStatisticsTestingInfo = structure(list(
-    significancearrowratio = structure(c(1, 1, 1, 0, 0.588688946015424,
-    1, 0, 1), dim = 8L), significancedirection = structure(c("Down",
-    "Up", "Down", "None", "Up", "Up", "None", "Up"), dim = 8L),
-    significancefontsizemultiplier = structure(c(0.204498977505112,
-    4.89, 0.204498977505112, 1, 3.29, 4.89, 1, 4.89), dim = 8L),
-    significanceissignificant = structure(c(TRUE, TRUE, TRUE,
-    FALSE, TRUE, TRUE, FALSE, TRUE), dim = 8L), zstatistic = structure(c(-8.70839337178774,
-    6.1826076764711, -6.53422517465904, 0.685654121466462, 3.43413089896878,
-    5.52625501318697, -0.586029163646552, 170.639971870602), dim = 8L),
-    pcorrected = structure(c(3.08212076761074e-18, 6.30512753119206e-10,
-    6.39396864465964e-11, 0.492931244011513, 0.000594457051110497,
-    3.27138529598869e-08, 0.557855916890687, 0), dim = 8L)), class = "data.frame", row.names = c(NA,
-8L)), questiontypes = "PickOne", footer.html = "&lt;div data-editable=\"true\" style=\"font-family:'Open
- Sans', sans-serif;font-size:8pt;font-weight:normal;font-style:normal;text-decoration:none;color:#505050
-;text-align:center;\"&gt;S1 Age 2 SUMMARY&lt;br /&gt;sample size = 4853; 95% confidence level&lt;/div&gt
-;", name = "table.S1.Age.2", questions = c("S1 Age 2",
-"SUMMARY"), class = c("qTable", "array"))
-    checkAttribute(agespans[1:2], "span",
-                   list(rows = data.frame(rep("&lt;25", 2), c("15-18", "19 to 24"), fix.empty.names = FALSE)))
+    values <- c(9.91, 17.39, 11, 14.63, 16.01, 17.06, 13.99, 100)
+    value.names <- c("15-18", "19 to 24", "25 to 29", "30 to 34", "35 to 39", "40 to 44", "45 to 49", "NET")
+    age.table <- array(values, dim = length(values), dimnames = list(value.names))
+    age.span <- data.frame(c("&lt;25", "&lt;25", "25-39", "25-39", "25-39", NA, NA, NA),
+                           value.names,
+                           fix.empty.names = FALSE)
+    attr(age.table, "span") <- list(rows = age.span)
+    class(age.table) <- c("qTable", class(age.table))
+    checkAttribute(age.table[1:2], "span",
+                   list(rows = age.span[1:2, ]))
+    checkAttribute(age.table[2:3], "span",
+                   list(rows = age.span[2:3, ]))
+    checkAttribute(age.table[c(1, 3)], "span",
+                   list(rows = age.span[c(1, 3), ]))
+    checkAttribute(age.table[c(1, 7)], "span",
+                   list(rows = age.span[c(1, 7), ]))
+    # Drop the span if it is not there (all NA)
+    checkAttribute(age.table[6:7], "span", NULL)
 })

--- a/tests/testthat/test-subscript-tables.R
+++ b/tests/testthat/test-subscript-tables.R
@@ -252,10 +252,17 @@ test_that("Span attributes retained properly", {
     class(age.table) <- c("qTable", class(age.table))
     checkSpanAttribute(age.table[1:2], NULL)
     checkSpanAttribute(age.table[c("19 to 24", "45 to 49")], NULL)
+    checkSpanAttribute(age.table[as.logical(rep(c(1L, 0L), c(2L, 4L)))], NULL)
     empty.span <- data.frame(value.names, fix.empty.names = FALSE)
     attr(age.table, "span") <- empty.span
     checkSpanAttribute(age.table[1:2], NULL)
     checkSpanAttribute(age.table[c("19 to 24", "45 to 49")], NULL)
+    logical.age.table <- array(FALSE, dim = dim(age.table))
+    age.table.logical <- logical.age.table
+    age.table.logical[1:2] <- TRUE
+    checkSpanAttribute(age.table[age.table.logical], NULL)
+    int.mat.age.table <- which(age.table.logical, arr.ind = TRUE)
+    checkSpanAttribute(age.table[int.mat.age.table], NULL)
     ############
     ## 2d case #
     ############
@@ -272,10 +279,16 @@ test_that("Span attributes retained properly", {
                                          fix.empty.names = FALSE))
     empty.span <- list(rows = data.frame(rownames(table.2d), fix.empty.names = FALSE),
                        columns = data.frame(colnames(table.2d), fix.empty.names = FALSE))
+    logical.2d.mat <- array(FALSE, dim = dim(table.2d))
     class(table.2d) <- c("qTable", class(table.2d))
     checkSpanAttribute(table.2d[1:2, 3:4], NULL)
     attr(age.table, "span") <- empty.span
     checkSpanAttribute(table.2d[1:2, 3:4], NULL)
+    table.2d.logical <- logical.2d.mat
+    table.2d.logical[1:2, 3:4] <- TRUE
+    checkSpanAttribute(table.2d[table.2d.logical], NULL)
+    int.mat.2d <- which(table.2d.logical, arr.ind = TRUE)
+    checkSpanAttribute(table.2d[int.mat.2d], NULL)
     ############
     ## 3d case #
     ############
@@ -287,6 +300,13 @@ test_that("Span attributes retained properly", {
                        columns = data.frame(colnames(table.3d), fix.empty.names = FALSE))
     attr(table.3d, "span") <- empty.span
     checkSpanAttribute(table.3d[1:6, , ], NULL)
+    table.3d.logical <- array(FALSE, dim = dim(table.3d))
+    table.3d.mat <- table.3d.logical
+    table.3d.mat[1:6, , ] <- TRUE
+    checkSpanAttribute(table.3d[1:6, , ], NULL)
+    checkSpanAttribute(table.3d[table.3d.mat], NULL)
+    int.mat.3d <- which(table.3d.mat, arr.ind = TRUE)
+    checkSpanAttribute(table.3d[int.mat.3d], NULL)
     ###################
     # General 1d case #
     ###################
@@ -294,14 +314,34 @@ test_that("Span attributes retained properly", {
                            value.names,
                            fix.empty.names = FALSE)
     attr(age.table, "span") <- list(rows = age.span)
-    checkSpanAttribute(age.table[1:2], list(rows = age.span[1:2, ]))
-    checkSpanAttribute(age.table[c("15-18", "19 to 24")], list(rows = age.span[1:2, ]))
-    checkSpanAttribute(age.table[2:3], list(rows = age.span[2:3, ]))
-    checkSpanAttribute(age.table[c("19 to 24", "25 to 29")], list(rows = age.span[2:3, ]))
-    checkSpanAttribute(age.table[c(1, 3)], list(rows = age.span[c(1, 3), ]))
-    checkSpanAttribute(age.table[c("15-18", "25 to 29")], list(rows = age.span[c(1, 3), ]))
-    checkSpanAttribute(age.table[c(1, 7)], list(rows = age.span[c(1, 7), ]))
-    checkSpanAttribute(age.table[c("15-18", "45 to 49")], list(rows = age.span[c(1, 7), ]))
+    expected.span <- list(rows = age.span[1:2, ])
+    checkSpanAttribute(age.table[1:2], expected.span)
+    checkSpanAttribute(age.table[c("15-18", "19 to 24")], expected.span)
+    age.table.logical <- logical.age.table
+    age.table.logical[1:2] <- TRUE
+    checkSpanAttribute(age.table[age.table.logical], expected.span)
+    checkSpanAttribute(age.table[which(age.table.logical, arr.ind = TRUE)], expected.span)
+    expected.span <- list(rows = age.span[2:3, ])
+    checkSpanAttribute(age.table[2:3], expected.span)
+    checkSpanAttribute(age.table[c("19 to 24", "25 to 29")], expected.span)
+    age.table.logical <- logical.age.table
+    age.table.logical[2:3] <- TRUE
+    checkSpanAttribute(age.table[age.table.logical], expected.span)
+    checkSpanAttribute(age.table[which(age.table.logical, arr.ind = TRUE)], expected.span)
+    expected.span <- list(rows = age.span[c(1, 3), ])
+    checkSpanAttribute(age.table[c(1, 3)], expected.span)
+    checkSpanAttribute(age.table[c("15-18", "25 to 29")], expected.span)
+    age.table.logical <- logical.age.table
+    age.table.logical[c(1, 3)] <- TRUE
+    checkSpanAttribute(age.table[age.table.logical], expected.span)
+    checkSpanAttribute(age.table[which(age.table.logical, arr.ind = TRUE)], expected.span)
+    expected.span <-  list(rows = age.span[c(1, 7), ])
+    checkSpanAttribute(age.table[c(1, 7)], expected.span)
+    checkSpanAttribute(age.table[c("15-18", "45 to 49")], expected.span)
+    age.table.logical <- logical.age.table
+    age.table.logical[c(1, 7)] <- TRUE
+    checkSpanAttribute(age.table[age.table.logical], expected.span)
+    checkSpanAttribute(age.table[which(age.table.logical, arr.ind = TRUE)], expected.span)
     # Drop the span if it is not there (all NA)
     checkSpanAttribute(age.table[6:7], NULL)
     checkSpanAttribute(age.table[c("40 to 44", "45 to 49")], NULL)
@@ -324,23 +364,33 @@ test_that("Span attributes retained properly", {
     class(table.2d) <- c("qTable", class(table.2d))
     ## Cell reference checks
     ### All in first column
-    expected.span <- span.2d
-    expected.span[[1L]] <- span.2d[[1L]][1:2, ]
-    expected.span[[2L]] <- NULL
-    checkSpanAttribute(table.2d[1:2], expected.span)
+    checkSpanAttribute(table.2d[1:2], NULL)
+    table.2d.logical <- logical.2d.mat
+    table.2d.logical[1:2] <- TRUE
+    checkSpanAttribute(table.2d[table.2d.logical], NULL)
+    checkSpanAttribute(table.2d[which(table.2d.logical, arr.ind = TRUE)], NULL)
     ### All in 3rd column
-    expected.span <- span.2d
-    expected.span[[1L]] <- span.2d[[1L]][1:6, ]
-    expected.span[[2L]] <- span.2d[[2L]][3, ]
-    checkSpanAttribute(table.2d[6 * 2 + 1:6], expected.span)
+    checkSpanAttribute(table.2d[6 * 2 + 1:6], NULL)
+    table.2d.logical <- logical.2d.mat
+    table.2d.logical[6 * 2 + 1:6] <- TRUE
+    checkSpanAttribute(table.2d[table.2d.logical], NULL)
+    checkSpanAttribute(table.2d[which(table.2d.logical, arr.ind = TRUE)], NULL)
     ### Don't return span attribute if cell references are not a slice of the array
     checkSpanAttribute(table.2d[c(1, 3, 5, 7, 12)], NULL)
+    table.2d.logical <- logical.2d.mat
+    table.2d.logical[c(1, 3, 5, 7, 12)] <- TRUE
+    checkSpanAttribute(table.2d[table.2d.logical], NULL)
+    checkSpanAttribute(table.2d[which(table.2d.logical, arr.ind = TRUE)], NULL)
     ## Row checks
     ### Subscripting only rows with a span, all columns included
     expected.span <- span.2d
     expected.span[[1L]] <- expected.span[[1L]][1:2, ]
     checkSpanAttribute(table.2d[1:2, ], expected.span)
     checkSpanAttribute(table.2d[c("Coca Cola", "Diet Coke"), ], expected.span)
+    table.2d.logical <- logical.2d.mat
+    table.2d.logical[1:2, ] <- TRUE
+    checkSpanAttribute(table.2d[table.2d.logical], NULL)
+    checkSpanAttribute(table.2d[which(table.2d.logical, arr.ind = TRUE)], NULL)
     expected.span <- span.2d
     expected.span[[1L]] <- expected.span[[1L]][1:4, ]
     checkSpanAttribute(table.2d[1:4, ], expected.span)

--- a/tests/testthat/test-subscript-tables.R
+++ b/tests/testthat/test-subscript-tables.R
@@ -235,3 +235,10 @@ test_that("drop and exact recognised and used appropriately", {
     expect_error(x.6.5.named[[2, 3, Exact = TRUE]], expected.error, fixed = TRUE)
     expect_error(x.6.5.named[[2, 3, exact = "TRUE"]], "exact argument should be TRUE or FALSE")
 })
+
+checkAttribute <- function(x, attr.name, desired.attr) {
+    x.attributes <- attributes(x)
+    expect_true(attr.name %in% names(x.attributes))
+    x.attr <- attr(x, attr.name)
+    expect_equal(x.attr, desired.attr)
+}

--- a/tests/testthat/test-subscript-tables.R
+++ b/tests/testthat/test-subscript-tables.R
@@ -242,3 +242,38 @@ checkAttribute <- function(x, attr.name, desired.attr) {
     x.attr <- attr(x, attr.name)
     expect_equal(x.attr, desired.attr)
 }
+
+test_that("Span attributes retained properly", {
+    agespans <- structure(c(`15-18` = 9.91139501339378, `19 to 24` = 17.3913043478261,
+`25 to 29` = 11.0035029878426, `30 to 34` = 14.6301256954461,
+`35 to 39` = 16.0107150216361, `40 to 44` = 17.0616113744076,
+`45 to 49` = 13.9913455594478, NET = 100), dim = 8L, dimnames = list(
+    c("15-18", "19 to 24", "25 to 29", "30 to 34", "35 to 39",
+    "40 to 44", "45 to 49", "NET")), statistic = "%", span = list(
+    rows = structure(list(c("&lt;25", "&lt;25", "25-39", "25-39",
+    "25-39", NA, NA, NA), c("15-18", "19 to 24", "25 to 29",
+    "30 to 34", "35 to 39", "40 to 44", "45 to 49", "NET")), class = "data.frame", names = c("",
+    ""), row.names = c(NA, 8L))), basedescriptiontext = "sample size = 4853", basedescription = list(
+    Minimum = 4853L, Maximum = 4853L, Range = FALSE, Total = 4853L,
+    Missing = 0L, EffectiveSampleSize = 4853L, EffectiveSampleSizeProportion = 100,
+    FilteredProportion = 0), QStatisticsTestingInfo = structure(list(
+    significancearrowratio = structure(c(1, 1, 1, 0, 0.588688946015424,
+    1, 0, 1), dim = 8L), significancedirection = structure(c("Down",
+    "Up", "Down", "None", "Up", "Up", "None", "Up"), dim = 8L),
+    significancefontsizemultiplier = structure(c(0.204498977505112,
+    4.89, 0.204498977505112, 1, 3.29, 4.89, 1, 4.89), dim = 8L),
+    significanceissignificant = structure(c(TRUE, TRUE, TRUE,
+    FALSE, TRUE, TRUE, FALSE, TRUE), dim = 8L), zstatistic = structure(c(-8.70839337178774,
+    6.1826076764711, -6.53422517465904, 0.685654121466462, 3.43413089896878,
+    5.52625501318697, -0.586029163646552, 170.639971870602), dim = 8L),
+    pcorrected = structure(c(3.08212076761074e-18, 6.30512753119206e-10,
+    6.39396864465964e-11, 0.492931244011513, 0.000594457051110497,
+    3.27138529598869e-08, 0.557855916890687, 0), dim = 8L)), class = "data.frame", row.names = c(NA,
+8L)), questiontypes = "PickOne", footer.html = "&lt;div data-editable=\"true\" style=\"font-family:'Open
+ Sans', sans-serif;font-size:8pt;font-weight:normal;font-style:normal;text-decoration:none;color:#505050
+;text-align:center;\"&gt;S1 Age 2 SUMMARY&lt;br /&gt;sample size = 4853; 95% confidence level&lt;/div&gt
+;", name = "table.S1.Age.2", questions = c("S1 Age 2",
+"SUMMARY"), class = c("qTable", "array"))
+    checkAttribute(agespans[1:2], "span",
+                   list(rows = data.frame(rep("&lt;25", 2), c("15-18", "19 to 24"), fix.empty.names = FALSE)))
+})


### PR DESCRIPTION
- DS-3806 Add basic testing function for attributes
- DS-3806 Add temporary test case
- DS-3806 Add template for attribute update [revdep skip]
- DS-3806 Evalaute arguments in correct frame
- DS-3806 Use evaluated args in span [revdep skip]
- DS-3806 Extend to 2d and 2d with multiple stats
- DS-3806 Simplify test code calls
- DS-3806 Retain spans with character matching [revdep skip]
