### PR TITLE
DS-3869: Fix of reordering QStatTestInfo attr for 2D multi-stat qTables

### DIFF
--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -366,7 +366,14 @@ updateQStatisticsTestingInfo <- function(y, x.attributes, evaluated.args,
                               collapse = "")
         new.ord <- match(new.idx.str, curr.idx.str)
         q.test.info <- q.test.info[new.ord, ]
+    }else if (is.multi.stat && !is.null(q.test.info[["Row"]]))
+    {
+        new.idx.str <- dimnames(y)[[1]]
+        curr.idx.str <- q.test.info[, "Row"]
+        new.ord <- match(new.idx.str, curr.idx.str)
+        q.test.info <- q.test.info[new.ord, ]
     }
+
     ##  if no labels on original table, create new numeric indices based on new dimensions
     if (orig.missing.names && any(colnames(q.test.info) %in% new.dim.names.names))
         q.test.info[, new.dim.names.names] <-

--- a/tests/testthat/test-subscript-tables.R
+++ b/tests/testthat/test-subscript-tables.R
@@ -1560,3 +1560,15 @@ test_that("DS-3846: Ensure higher order dim tables can be flattened", {
     expected.span.dims <- c("Inner Row", "Outer Column")
     for (tbl in two.by.two.tbls) subscriptCompleteTable(tbl, expected.span.dims)
 })
+
+test_that("DS-3869: QStatTestInfo correct when reordering rows of multi-stat tbl of 1D q.",
+{
+    tbl <- tbls[["PickOne"]]
+    tbl.ms <- makeMultistat(tbl)
+    idx <- c(2, 4, 1, 3)
+    out <- tbl.ms[idx, ]
+    q.test.info.out <- attr(out, "QStatisticsTestingInfo")
+    expect_equal(q.test.info.out[, "zstatistic"], unclass(tbl.ms)[idx, 1],
+                 check.attributes = FALSE)
+    expect_equal(as.character(q.test.info.out[, "Row"]), rownames(out))
+})


### PR DESCRIPTION
* Reordering step at the end of `updateStatisticalTestingInfo` was being skipped for the case of a multi-stat summary qTable of a 1D question