### PR TITLE
DS-3873: Fix when dropping both dimensions from a grid-question summary qTable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: verbs
 Type: Package
 Title: A Grammar for Common Data Manipulations and Summaries
-Version: 0.14.8
+Version: 0.14.9
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: A collection of operations/actions/"verbs" providing an intuitive interface for many common operations (e.g. Sum, First, Average, Maximum, ...) on various inputs/data structures. Created to simplify common user actions in Displayr with a wide variety of inputs.

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -609,16 +609,11 @@ updateQuestionTypesFromArgs <- function(dropped.dims, question.type) {
     question.type
 }
 
-getFallbackQuestionType <- function(question.types, all.relevant.dims.dropped) {
-    n.question.types <- length(question.types)
-    if (n.question.types == 1L || all.relevant.dims.dropped) {
-        if (question.types[1L] %in% c("NumberMulti", "NumberGrid")) return("Number")
-        else if (question.types[1L] %in% c("PickOneMulti", "PickAnyGrid")) return("PickAny")
-        return(question.types[1L])
-    }
-    if (identical(question.types[1], question.types[2]))
-        return(question.types[1])
-    question.types[which.max(nchar(question.types))]
+getFallbackQuestionType <- function(statistics)
+{
+    if (!is.null(statistics) && any(endsWith(statistics, "%")))
+        return("PickAny")
+    else return("Number")
 }
 
 updateQuestionTypesAttr <- function(y, x.attr, evaluated.args, drop = TRUE) {
@@ -675,7 +670,12 @@ updateQuestionTypesAttr <- function(y, x.attr, evaluated.args, drop = TRUE) {
                       SIMPLIFY = TRUE, USE.NAMES = FALSE))
     }
     if (is.null(new.question.types))
-        new.question.types <- getFallbackQuestionType(x.question.types, all(dropped.dims))
+    {
+        stat.names <- if (is.multi.stat)
+                          x.dimnames[[length(x.dimnames)]]
+                      else x.attr[["statistic"]]
+        new.question.types <- getFallbackQuestionType(stat.names)
+    }
     attr(y, "questiontypes") <- new.question.types
     y
 }

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -610,7 +610,8 @@ updateQuestionTypesFromArgs <- function(dropped.dims, question.type) {
 getFallbackQuestionType <- function(question.types) {
     n.question.types <- length(question.types)
     if (n.question.types == 1L) {
-        if (question.types == "NumberMulti") return("Number")
+        if (question.types %in% c("NumberMulti", "NumberGrid")) return("Number")
+        else if (question.types %in% c("PickOneMulti", "PickAnyGrid")) return("PickAny")
         return(question.types)
     }
     if (identical(question.types[1], question.types[2]))

--- a/R/subscript-tables.R
+++ b/R/subscript-tables.R
@@ -506,6 +506,8 @@ subscriptSpanDF <- function(span.attr, idx) {
 updateSpanIfNecessary <- function(y, x.attributes, evaluated.args) {
     span.attribute <- x.attributes[["span"]]
     if (is.null(span.attribute)) return(y)
+    if (all(vapply(span.attribute, length, 0L) == 0L))
+        return(structure(y, span = span.attribute))
     x.dim <- x.attributes[["dim"]]
     dim.length <- length(x.dim)
     # Span will be dropped if single indexing argument (vector or matrix etc) used on an array
@@ -607,12 +609,12 @@ updateQuestionTypesFromArgs <- function(dropped.dims, question.type) {
     question.type
 }
 
-getFallbackQuestionType <- function(question.types) {
+getFallbackQuestionType <- function(question.types, all.relevant.dims.dropped) {
     n.question.types <- length(question.types)
-    if (n.question.types == 1L) {
-        if (question.types %in% c("NumberMulti", "NumberGrid")) return("Number")
-        else if (question.types %in% c("PickOneMulti", "PickAnyGrid")) return("PickAny")
-        return(question.types)
+    if (n.question.types == 1L || all.relevant.dims.dropped) {
+        if (question.types[1L] %in% c("NumberMulti", "NumberGrid")) return("Number")
+        else if (question.types[1L] %in% c("PickOneMulti", "PickAnyGrid")) return("PickAny")
+        return(question.types[1L])
     }
     if (identical(question.types[1], question.types[2]))
         return(question.types[1])
@@ -673,7 +675,7 @@ updateQuestionTypesAttr <- function(y, x.attr, evaluated.args, drop = TRUE) {
                       SIMPLIFY = TRUE, USE.NAMES = FALSE))
     }
     if (is.null(new.question.types))
-        new.question.types <- getFallbackQuestionType(x.question.types)
+        new.question.types <- getFallbackQuestionType(x.question.types, all(dropped.dims))
     attr(y, "questiontypes") <- new.question.types
     y
 }

--- a/tests/testthat/test-subscript-tables.R
+++ b/tests/testthat/test-subscript-tables.R
@@ -1001,8 +1001,8 @@ test_that("DS-3843 questiontypes attribute is modified correctly",
     ## PickOne
     tbl <- tbls[["PickOne"]]
     checkQuestionTypesAttr(tbl[1:3], "PickOne")
-    checkQuestionTypesAttr(tbl[1], "PickOne")
-    checkQuestionTypesAttr(tbl["Under 40"], "PickOne")
+    checkQuestionTypesAttr(tbl[1], "Number")
+    checkQuestionTypesAttr(tbl["Under 40"], "Number")
     checkQuestionTypesAttr(tbl[], "PickOne")
     checkQuestionTypesAttr(tbl[1:3, drop = FALSE], "PickOne")
 
@@ -1579,13 +1579,14 @@ test_that("DS-3873: Can subset 1D multi-stat table",
     tbl <- tbls[["PickOneMulti"]]
     tbl.ms <- makeMultistat(tbl)
     out <- tbl.ms[2, 3, ]
-    expect_equal(attr(out, "questiontype"), "PickAny")
+    expect_equal(attr(out, "questiontype"), "Number")
     expect_error(q.test.info.out <- attr(out[1], "QStatisticsTestingInfo"), NA)
     expect_equal(q.test.info.out[, "zstatistic"], unclass(tbl.ms)[2, 3, 1],
                check.attributes = FALSE)
 
     tbl <- tbls[["PickAnyGrid.by.NumberGrid"]]
     tbl.ms <- makeMultistat(tbl)
+    dimnames(tbl.ms)[[5L]] <- c("Column %", "Row %")
     out <- tbl.ms[3, 1, 2, 2, ]
     expect_equal(attr(out, "questiontype"), "PickAny")
     expect_error(q.test.info.out <- attr(out[1], "QStatisticsTestingInfo"), NA)

--- a/tests/testthat/test-subscript-tables.R
+++ b/tests/testthat/test-subscript-tables.R
@@ -1583,4 +1583,13 @@ test_that("DS-3873: Can subset 1D multi-stat table",
     expect_error(q.test.info.out <- attr(out[1], "QStatisticsTestingInfo"), NA)
     expect_equal(q.test.info.out[, "zstatistic"], unclass(tbl.ms)[2, 3, 1],
                check.attributes = FALSE)
+
+    tbl <- tbls[["PickAnyGrid.by.NumberGrid"]]
+    tbl.ms <- makeMultistat(tbl)
+    out <- tbl.ms[3, 1, 2, 2, ]
+    expect_equal(attr(out, "questiontype"), "PickAny")
+    expect_error(q.test.info.out <- attr(out[1], "QStatisticsTestingInfo"), NA)
+    expect_equal(q.test.info.out[, "zstatistic"], unclass(tbl.ms)[3, 1, 2, 2, 1],
+                 check.attributes = FALSE)
+
 })

--- a/tests/testthat/test-subscript-tables.R
+++ b/tests/testthat/test-subscript-tables.R
@@ -1572,3 +1572,15 @@ test_that("DS-3869: QStatTestInfo correct when reordering rows of multi-stat tbl
                  check.attributes = FALSE)
     expect_equal(as.character(q.test.info.out[, "Row"]), rownames(out))
 })
+
+
+test_that("DS-3873: Can subset 1D multi-stat table",
+{
+    tbl <- tbls[["PickOneMulti"]]
+    tbl.ms <- makeMultistat(tbl)
+    out <- tbl.ms[2, 3, ]
+    expect_equal(attr(out, "questiontype"), "PickAny")
+    expect_error(q.test.info.out <- attr(out[1], "QStatisticsTestingInfo"), NA)
+    expect_equal(q.test.info.out[, "zstatistic"], unclass(tbl.ms)[2, 3, 1],
+               check.attributes = FALSE)
+})


### PR DESCRIPTION
* When dropping both dimensions from a grid question summary tbl with
multiple statistics, the updated questiontype attr. was still a grid
question, leading to an error in nameDimensionAttributes b/c a 1D
tbl was erroneously being said to contain a 2D question