### PR TITLE
DS-5129: Support multiple calls to [.QTable with duplicate labels

### DIFF
--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -79,6 +79,9 @@
     if (input.is.not.array)
         x <- as.array(x)
 
+    DUPLICATE.LABEL.SUFFIX  <- "_@_"
+    x <- deduplicateQTableLabels(x, DUPLICATE.LABEL.SUFFIX)
+
     x.dim <- dim(x)
 
     if (empty.ind)
@@ -115,6 +118,7 @@
     # Update Attributes here
     y <- updateTableAttributes(y, x, called.args, evaluated.args, drop = TRUE, missing.names)
     y <- updateNameAttribute(y, attr(x, "name"), called.args, "[[")
+    y <- removeDeduplicationSuffixFromLabels(y, DUPLICATE.LABEL.SUFFIX)
     if (missing.names)
         y <- unname(y)
     y

--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -946,7 +946,7 @@ deduplicateQTableLabels <- function(x, sep = "_@_")
         
     throwWarningIfDuplicateLabels(original.names, new.names)
     dimnames(x) <- new.names
-    return(x)a
+    return(x)
 }
 
 removeDeduplicationSuffixFromLabels <- function(x, sep = "_@_")

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -2343,3 +2343,13 @@ test_that("DS-5120 Turn off subcripting in Q", {
     rm("productName", envir = .GlobalEnv)
     rm("allowQTableSubscripting", envir = .GlobalEnv)
 })
+
+test_that("DS-5129: Subscripting twice with duplicate labels",
+{
+    input <- duplicate.labels.tests[[2]]$input
+    output <- suppressWarnings(input[1:4, , ][, 1:2, 2])
+    expected <- as.numeric(t(output))
+    z.stat.output <- attr(output, "QStatisticsTestingInfo")[, "zstatistic"]
+    dim(z.stat.output) <- NULL
+    expect_equal(expected, z.stat.output, ignore_attr = TRUE)
+})


### PR DESCRIPTION
* Move code to deduplicate array indices added to QStatisticsTestingInfo to addArrayIndicesIfMissing, since expand.grid() creates factor columns and factor levels can't have duplicates
* For this reason, don't remove deduplication suffix from array indices in the TestingInfo and removeDeduplicationSuffixFromTestingInfo and deduplicateTestingInfo from DS-5092, DS-5093 have been removed