### PR TITLE
DS-5302 Handle undropped subscripted multi-stat tables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: verbs
 Type: Package
 Title: A Grammar for Common Data Manipulations and Summaries
-Version: 0.15.5
+Version: 0.15.6
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: A collection of operations/actions/"verbs" providing an intuitive interface for many common operations (e.g. Sum, First, Average, Maximum, ...) on various inputs/data structures. Created to simplify common user actions in Displayr with a wide variety of inputs.

--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -427,7 +427,7 @@ updateQStatisticsTestingInfo <- function(y, x.attributes, evaluated.args,
     }
     qtypes <- x.attributes[["questiontypes"]]
 
-    vector.or.single.dim.output <- is.null(dim(y)) || getDimensionLength(y) == 1L
+    vector.or.single.dim.output <- is.null(dim(y)) || length(y) == 1L || getDimensionLength(y) == 1L
     if (vector.or.single.dim.output)
     {
         keep.rows <- getQTestInfoIndexForVectorOutput(
@@ -437,11 +437,13 @@ updateQStatisticsTestingInfo <- function(y, x.attributes, evaluated.args,
             has.multi.stat.dim = is.multi.stat && length(evaluated.args) == 1L,
             q.stat.info.len = nrow(q.test.info)
         )
-        attr(y, "QStatisticsTestingInfo") <- q.test.info[keep.rows, ]
+        attr(y, "QStatisticsTestingInfo") <- q.test.info[keep.rows, , drop = FALSE]
         return(y)
     }
     idx.array <- array(FALSE, dim = dim.x, dimnames = dimnames.x)
     idx.array <- do.call(`[<-`, c(list(idx.array), evaluated.args, value = TRUE))
+    if (!is.array(idx.array)) # Need an array for aperm
+        idx.array <- as.array(idx.array)
     perm <- rowMajorDimensionPermutation(dim.len, qtypes)
     idx.array <- aperm(idx.array, perm)  # match(seq_len(dim.len), perm)
 

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -2388,3 +2388,68 @@ test_that("DS-5149 - Permute order of 1d table", {
         )
     }
 })
+
+test_that("Multiple stats and dropping", {
+    # PickOne with multiple stats
+    x <- structure(
+        array(1:6, dim = c(3L, 2L), dimnames = list(LETTERS[1:3], c("%", "Count"))),
+        questiontypes = "PickOne",
+        name = "some.table",
+        QStatisticsTestingInfo = data.frame(
+            zstatistic = c(-1.71, 1.71, 24.98)
+        ),
+        class = c("QTable", "matrix", "array")
+    )
+    # Down to a scalar without dropping
+    expected.output <- unclass(x)["A", "Count", drop = FALSE]
+    attributes(expected.output) <- list(
+        dim = c(1L, 1L),
+        dimnames = list("A", "Count"),
+        QStatisticsTestingInfo = data.frame(
+            zstatistic = -1.71
+        ),
+        questiontypes = "PickOne",
+        original.questiontypes = "PickOne",
+        class = c("QTable", "matrix", "array"),
+        original.name = "some.table",
+        name = "some.table[A,Count]",
+        is.subscripted = TRUE,
+        mapped.dimnames = list(
+            Row = "A",
+            Statistic = "Count"
+        )
+    )
+    expect_equal(
+        x["A", "Count", drop = FALSE],
+        expected.output
+    )
+    # Down to two values without dropping
+    expected.output <- unclass(x)[c("A", "C"), "Count", drop = FALSE]
+    attributes(expected.output) <- list(
+        dim = c(2, 1L),
+        dimnames = list(c("A", "C"), "Count"),
+        QStatisticsTestingInfo = structure(
+            list(
+                Row = factor(c("A", "C")),
+                zstatistic = c(-1.71, 24.98)
+            ),
+            row.names = c(1L, 3L),
+            class = "data.frame"
+        ),
+        questiontypes = "PickOne",
+        original.questiontypes = "PickOne",
+        class = c("QTable", "matrix", "array"),
+        original.name = "some.table",
+        name = "some.table[c(\"A\", \"C\"),Count]",
+        is.subscripted = TRUE,
+        mapped.dimnames = list(
+            Row = c("A", "C"),
+            Statistic = "Count"
+        )
+    )
+    expect_equal(
+        x[c("A", "C"), "Count", drop = FALSE],
+        expected.output
+    )
+
+})


### PR DESCRIPTION
Edge cases where a single dim is extracted (or scalar) from a multi stat
table with drop = FALSE have been patched by forcing the input to aperm
to be an array if the `[<-` call simplified it. Also a scalar output is
resolved in an earlier path for simplicity.
