### PR TITLE
Untracked: Move flipStatistics tests to flipStatistics

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,11 @@
 Package: verbs
 Type: Package
 Title: A Grammar for Common Data Manipulations and Summaries
-Version: 0.15.12
+Version: 0.15.13
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: A collection of operations/actions/"verbs" providing an intuitive interface for many common operations (e.g. Sum, First, Average, Maximum, ...) on various inputs/data structures. Created to simplify common user actions in Displayr with a wide variety of inputs.
 Suggests:
-    flipStatistics,
     testthat,
     abind
 License: GPL-3
@@ -25,7 +24,6 @@ Remotes:
     Displayr/flipFormat,
     Displayr/flipTime,
     Displayr/flipTransformations,
-    Displayr/flipStatistics,
     Displayr/flipU
 RoxygenNote: 7.3.2
 Depends:

--- a/R/select.R
+++ b/R/select.R
@@ -259,10 +259,12 @@ checkSelections <- function(indices, ...)
 #' @export
 checkSelections.default <- function(indices, ...)
 {
-    if (!inherits(indices, c("numeric", "factor", "character")))
-        StopForUserError("Supplied format for selections is not valid.",
-             " Selections should be a integer, character, or logical vector.",
-             call. = FALSE)
+    if (!inherits(indices, c("numeric", "factor", "character"))) {
+        StopForUserError(
+            "Supplied format for selections is not valid. ",
+            "Selections should be a integer, character, or logical vector."
+        )
+    }
     NextMethod("checkSelections")
 }
 

--- a/tests/testthat/test-average.R
+++ b/tests/testthat/test-average.R
@@ -114,8 +114,6 @@ test_that("Variables with weights, filters (subset), and a combination of the tw
                         verbs:::determineAppropriateContact()),
                  fixed = TRUE)
     weights <- runif(length(variable.Numeric))
-    expect_equal(Average(variable.Numeric, weights = weights),
-                 flipStatistics::Mean(variable.Numeric, weights = weights))
     expect_equal(Average(variable.Numeric, variable.Nominal,
                          weights = weights),
                  Average(variable.Numeric, variable.Nominal))

--- a/tests/testthat/test-averagecolumns.R
+++ b/tests/testthat/test-averagecolumns.R
@@ -95,34 +95,12 @@ test_that("Variables with weights, filters (subset), and a combination of the tw
     expect_error(AverageEachColumn(variable.Numeric[1:10], subset = subset.missing.out),
                  subset.error)
     weights <- runif(length(variable.Numeric))
-    expect_equal(AverageEachColumn(variable.Numeric, weights = weights),
-                 c(Age = flipStatistics::Mean(variable.Numeric, weights = weights)))
     df.input <- data.frame(Age = variable.Numeric, `Coca-Cola` = variable.Binary, check.names = FALSE)
-    expect_equal(AverageEachColumn(df.input, weights = weights),
-                 c(Age = flipStatistics::Mean(variable.Numeric, weights = weights),
-                   `Coca-Cola` = flipStatistics::Mean(variable.Binary, weights = weights)))
-    df.input <- data.frame(Age = variable.Numeric, Age = variable.Nominal, check.names = FALSE)
-    expect_equal(AverageEachColumn(df.input,
-                                weights = weights,
-                                subset = subset.missing.out),
-                 c(Age = flipStatistics::Mean(variable.Numeric, weights = weights),
-                   Age = flipStatistics::Mean(flipTransformations::AsNumeric(variable.Nominal, binary = FALSE),
-                                              weights = weights)))
+
     weights.error <- capture_error(throwErrorSubsetOrWeightsWrongSize("weights", 10L, length(variable.Numeric)))[["message"]]
     expect_error(AverageEachColumn(variable.Numeric, weights = weights[1:10]),
                  weights.error)
     # Variable sets and data.frames
-    expect_equal(AverageEachColumn(data.frame(variable.Binary, variable.Nominal),
-                            subset = subset.missing.out, remove.missing = FALSE),
-                 c("Coca-Cola" = NA,
-                   "Age" = flipStatistics::Mean(flipTransformations::AsNumeric(variable.Nominal, binary = FALSE)[subset.missing.out])))
-    subset.binary <- !is.na(variable.Binary)
-    expect_equal(AverageEachColumn(data.frame(variable.Binary, variable.Nominal),
-                            subset = subset.binary, weights = weights,
-                            remove.missing = FALSE),
-                 c("Coca-Cola" = flipStatistics::Mean(variable.Binary[subset.binary],
-                                                            weights = weights[subset.binary]),
-                   "Age" = NA))
     df <- data.frame(variable.Binary,
                      variable.Nominal = flipTransformations::AsNumeric(variable.Nominal, binary = FALSE))
     weighted.df <- df * weights

--- a/tests/testthat/test-maxmin.R
+++ b/tests/testthat/test-maxmin.R
@@ -203,7 +203,11 @@ test_that("Min/Max uses ChartData if available",
 {
     var1 <- variable.Numeric
     var2 <- runif(length(var1))
-    correlation.output <- flipStatistics::CorrelationMatrix(data.frame(var1, var2))
+    correlation.output <- structure(
+        list(cor = expected.correlation),
+        ChartData = expected.correlation,
+        class = "CorrelationMatrix"
+    )
     expect_equal(Min(correlation.output),
                  min(attr(correlation.output, "ChartData")))
 })

--- a/tests/testthat/test-maxmin.R
+++ b/tests/testthat/test-maxmin.R
@@ -203,13 +203,14 @@ test_that("Min/Max uses ChartData if available",
 {
     var1 <- variable.Numeric
     var2 <- runif(length(var1))
+    expected.correlation <- data.frame(var1, var2) |> cor(use = "pairwise.complete.obs")
     correlation.output <- structure(
         list(cor = expected.correlation),
         ChartData = expected.correlation,
         class = "CorrelationMatrix"
     )
-    expect_equal(Min(correlation.output),
-                 min(attr(correlation.output, "ChartData")))
+    Min(correlation.output) |>
+        expect_equal(min(attr(correlation.output, "ChartData")))
 })
 
 test_that("A single R Output (e.g. a vanilla matrix or vector) selected",

--- a/tests/testthat/test-sum.R
+++ b/tests/testthat/test-sum.R
@@ -397,7 +397,12 @@ test_that("Summing list objects (e.g. model fits) and other R Outputs",
 { ## extracts ChartData and calls Sum again
     var1 <- variable.Numeric
     var2 <- runif(length(var1))
-    correlation.output <- flipStatistics::CorrelationMatrix(data.frame(var1, var2))
+    expected.correlation <- cor(data.frame(var1, var2), use = "complete.obs")
+    correlation.output <- structure(
+        list(cor = expected.correlation),
+        ChartData = expected.correlation,
+        class = "CorrelationMatrix"
+    )
     expect_equal(Sum(correlation.output), sum(cor(data.frame(var1, var2), use = "complete.obs")))
 })
 

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -431,9 +431,10 @@ test_that("Data types checked", {
 test_that("ExtractChartData", {
     var1 <- variable.Numeric
     var2 <- runif(length(var1))
-    correlation.output <- flipStatistics::CorrelationMatrix(data.frame(var1, var2))
-    expect_equivalent(extractChartDataIfNecessary(correlation.output),
-                      cor(data.frame(var1, var2), use = "complete.obs"))
+    expected.correlation <- cor(data.frame(var1, var2), use = "complete.obs")
+    correlation.output <- structure(list(cor = expected.correlation), ChartData = expected.correlation, class = "CorrelationMatrix")
+    extractChartDataIfNecessary(correlation.output) |>
+        expect_equal(structure(expected.correlation, assigned.rownames = TRUE))
 })
 
 # Helper function to shuffle second element, useful for the matching tests

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -231,11 +231,12 @@ test_that("Contact details correct", {
                  paste0("Contact support at ", contact.msg),
                  fixed = TRUE)
     # Expect customer support contact correct
-    expect_equal(with_mock(IsRServer = function() TRUE,
-                           determineAppropriateContact(),
-                           .env = "flipU"),
-                 "Contact support at support@displayr.com if you wish this to be changed.",
-                 fixed = TRUE)
+    with_mocked_bindings(
+        IsRServer = function() TRUE,
+        determineAppropriateContact(),
+        .package = "verbs"
+    ) |>
+        expect_equal("Contact support at support@displayr.com if you wish this to be changed.", fixed = TRUE)
     expect_error(throwErrorContactSupportForRequest("isn't supported. ", "'some func'"),
                  paste0("'some func' isn't supported. ", determineAppropriateContact()))
 })

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -1599,7 +1599,7 @@ test_that("All elements in dim removed throws informative error", {
         expect_error(Sum(t(input[[1]]), t(input[[2]]), remove.columns = remove.rows),
                      expected.error, fixed = TRUE)
     }
-    for(x in c(TRUE, FALSE)) with_mock(IsRServer = function() x, checkError(x), .env = "flipU")
+    for (x in c(TRUE, FALSE)) with_mocked_bindings(IsRServer = function() x, checkError(x), .package = "flipU")
 })
 
 test_that("No matches throws an informative error when matching requested", {

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -435,7 +435,7 @@ test_that("ExtractChartData", {
     expected.correlation <- cor(data.frame(var1, var2), use = "complete.obs")
     correlation.output <- structure(list(cor = expected.correlation), ChartData = expected.correlation, class = "CorrelationMatrix")
     extractChartDataIfNecessary(correlation.output) |>
-        expect_equal(structure(expected.correlation, assigned.rownames = TRUE))
+        expect_equal(expected.correlation)
 })
 
 # Helper function to shuffle second element, useful for the matching tests


### PR DESCRIPTION
Remove the Suggests: flipStatistics requirement as it is only used in testing. The affected tests are either converted to not require the flipStatistics functions or have been moved to flipStatistics.
