### PR TITLE
RS-19631: Fix handling of span attributes

### DIFF
--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -791,9 +791,11 @@ updateSpanIfNecessary <- function(y, x.attributes, evaluated.args) {
         span.df <- mapply(subscriptSpanDF, span.attribute, evaluated.args, SIMPLIFY = FALSE)
         span.df <- Filter(ncol, span.df)
         if (is.null(ncol(y)) && !is.null(span.df$columns)) {
+            nc <- ncol(span.df$columns)
             # When subscripting a row of a matrix results in a vector (i.e. drop = TRUE)
             # this is shown as a column vector even though transpose has not been called
-            span.df$rows <- span.df$columns
+            if (all(span.df$columns[,nc] == names(y)))
+                span.df$rows <- span.df$columns
             span.df$columns <- NULL
         }
         if (length(span.df)) attr(y, "span") <- span.df

--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -794,7 +794,7 @@ updateSpanIfNecessary <- function(y, x.attributes, evaluated.args) {
             nc <- ncol(span.df$columns)
             # When subscripting a row of a matrix results in a vector (i.e. drop = TRUE)
             # this is shown as a column vector even though transpose has not been called
-            if (all(span.df$columns[,nc] == names(y)))
+            if (length(names(y)) == nrow(span.df$columns) && all(span.df$columns[,nc] == names(y)))
                 span.df$rows <- span.df$columns
             span.df$columns <- NULL
         }

--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -791,10 +791,11 @@ updateSpanIfNecessary <- function(y, x.attributes, evaluated.args) {
         span.df <- mapply(subscriptSpanDF, span.attribute, evaluated.args, SIMPLIFY = FALSE)
         span.df <- Filter(ncol, span.df)
         if (is.null(ncol(y)) && !is.null(span.df$columns)) {
-            nc <- ncol(span.df$columns)
+            last.col <- ncol(span.df$columns) # this column contains the column labels
+
             # When subscripting a row of a matrix results in a vector (i.e. drop = TRUE)
             # this is shown as a column vector even though transpose has not been called
-            if (length(names(y)) == nrow(span.df$columns) && all(span.df$columns[,nc] == names(y)))
+            if (length(names(y)) == nrow(span.df$columns) && all(span.df$columns[,last.col] == names(y)))
                 span.df$rows <- span.df$columns
             span.df$columns <- NULL
         }

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -823,6 +823,15 @@ test_that("Span attributes retained properly", {
     attr(table.2d, "span") <- span.2d
     attr(table.2d, "statistic") <- "Row %"
     class(table.2d) <- c("QTable", class(table.2d))
+
+    # Check subscripting with dimensions dropped
+    sub.1row <- table.2d[2,]
+    expect_equal(attr(sub.1row, "span")$column, NULL)
+    expect_equal(attr(sub.1row, "span")$row, attr(table.2d, "span")$column)
+    sub.1col <- table.2d[,2]
+    expect_equal(attr(sub.1col, "span")$column, NULL)
+    expect_equal(attr(sub.1col, "span")$row, attr(table.2d, "span")$row)
+
     ## Cell reference checks
     ### All in first column
     checkSpanAttribute(table.2d[1:2], NULL)


### PR DESCRIPTION
The [previous fix](https://github.com/Displayr/verbs/pull/120) for span attributes addressed the case equivalent `sub.1row` in the unit test added. In this PR, we add an extra check for whether spans need to be swapped when dimensions are dropped (i.e. the `sub.1col`).