### PR TITLE
Revert "SAQ-2077: Insert subscripted dimnames into footerhtml attribute for improved visibility of table contents when printing (#126)"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: verbs
 Type: Package
 Title: A Grammar for Common Data Manipulations and Summaries
-Version: 0.15.16
+Version: 0.15.15
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: A collection of operations/actions/"verbs" providing an intuitive interface for many common operations (e.g. Sum, First, Average, Maximum, ...) on various inputs/data structures. Created to simplify common user actions in Displayr with a wide variety of inputs.

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -427,6 +427,7 @@ addQTableAttributesToFlattenedTable <- function(flattened.table, x.attr) {
     q.stat.info <- x.attr[["QStatisticsTestingInfo"]]
     x.attr[["QStatisticsTestingInfo"]] <- updateFlattenedDimensionsToQStatInfo(q.stat.info, x.attr[["dimnames"]])
     x.attr[["questiontypes"]] <- updateFlattenedQuestionTypes(x.attr[["questiontypes"]])
+    x.attr[["name"]] <- updateFlattenedName(x.attr[["name"]])
     if (output.is.array) {
         q.stat.info.names <- names(x.attr[["QStatisticsTestingInfo"]])
         dim.names.names <- c("Row", "Column")[c("Row", "Column") %in% q.stat.info.names]
@@ -436,6 +437,11 @@ addQTableAttributesToFlattenedTable <- function(flattened.table, x.attr) {
     }
     mostattributes(flattened.table) <- x.attr
     flattened.table
+}
+
+updateFlattenedName <- function(x) {
+    if (is.null(x)) return(x)
+    paste0("FlattenTable(", x, ")")
 }
 
 updateFlattenedDimensionsToQStatInfo <- function(q.stat.info, new.dimnames) {

--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -20,6 +20,7 @@
     if (input.is.not.array)
         x <- as.array(x)
 
+    DUPLICATE.LABEL.SUFFIX  <- "_@_"
     x <- deduplicateQTableLabels(x, DUPLICATE.LABEL.SUFFIX)
 
     x.dim <- dim(x)
@@ -49,6 +50,7 @@
     # Update Attributes here
     y <- updateTableAttributes(y, x, called.args, evaluated.args, drop = drop,
                                missing.names, DUPLICATE.LABEL.SUFFIX)
+    y <- updateNameAttribute(y, attr(x, "name"), called.args, "[")
     throwWarningIfDuplicateLabels(x, evaluated.args, sep = DUPLICATE.LABEL.SUFFIX)
     y <- removeDeduplicationSuffixFromLabels(y, DUPLICATE.LABEL.SUFFIX)
 
@@ -60,8 +62,6 @@
 
     y
 }
-
-DUPLICATE.LABEL.SUFFIX  <- "_@_"
 
 #' @importFrom flipU StopForUserError
 #' @export
@@ -82,6 +82,7 @@ DUPLICATE.LABEL.SUFFIX  <- "_@_"
     if (input.is.not.array)
         x <- as.array(x)
 
+    DUPLICATE.LABEL.SUFFIX  <- "_@_"
     x <- deduplicateQTableLabels(x, DUPLICATE.LABEL.SUFFIX)
 
     x.dim <- dim(x)
@@ -119,6 +120,7 @@ DUPLICATE.LABEL.SUFFIX  <- "_@_"
 
     # Update Attributes here
     y <- updateTableAttributes(y, x, called.args, evaluated.args, drop = TRUE, missing.names)
+    y <- updateNameAttribute(y, attr(x, "name"), called.args, "[[")
     y <- removeDeduplicationSuffixFromLabels(y, DUPLICATE.LABEL.SUFFIX)
     if (missing.names)
         y <- unname(y)
@@ -135,8 +137,12 @@ dropTableToVector <- function(x) {
     x
 }
 
-updateNameAttribute <- function(y, original.name) {
-    structure(y, name = original.name)
+updateNameAttribute <- function(y, original.name, called.args, subscript.type = "[")
+{
+    end.char <- if (subscript.type == "[") "]" else "]]"
+    subscript.args <- paste0(subscript.type, paste(as.character(called.args), collapse = ","), end.char)
+    attr(y, "name") <- paste0(original.name, subscript.args)
+    y
 }
 
 # named arguments to [ or [[ are the input itself (x) and i and j references
@@ -233,7 +239,7 @@ throwErrorOnlyNamed <- function(named.arg, function.name) {
                      sQuote(function.name))
 }
 
-isBasicAttribute <- function(attribute.names, basic.attr = c("dim", "names", "dimnames", "class", "name")) {
+isBasicAttribute <- function(attribute.names, basic.attr = c("dim", "names", "dimnames", "class")) {
     attribute.names %in% basic.attr
 }
 
@@ -269,104 +275,12 @@ updateTableAttributes <- function(y, x, called.args, evaluated.args, drop = TRUE
     x.attributes <- updateQuestionTypesIfDoesntMatchDim(x.attributes)
     y <- updateQuestionTypesAttr(y, x.attributes, evaluated.args, drop = drop)
     y <- updateQStatisticsTestingInfo(y, x.attributes, evaluated.args, original.missing.names, sep)
-    y <- updateNameAttribute(y, x.attributes[["name"]])
     y <- updateNameDimensionAttr(y, x.attributes[["dim"]])
     y <- updateSpanIfNecessary(y, x.attributes, evaluated.args)
     y <- updateIsSubscriptedAttr(y, x)
-    y <- updateFooterIfNecessary(y, x, evaluated.args)
     y <- updateCellText(y, x.attributes, evaluated.args)
     y <- keepMappedDimnames(y)
     y
-}
-
-#' Should convert a single string into a string wrapped in parantheses
-#' If an empty string (no characters) or NA is provided, returns NULL
-#' @noRd
-wrapNamesInParentheses <- function(x) {
-    if (!nzchar(x) || is.na(x)) {
-        return(NULL)
-    }
-    paste0("(", x, ")")
-}
-
-getLength <- function(x) {
-    if (!is.null(dim(x))) {
-        return(prod(dim(x)) |> as.integer())
-    }
-    length(x)
-}
-
-updateFooterIfNecessary <- function(y, x, evaluated.args) {
-    x.attributes <- attributes(x)
-    if (is.null(x.attributes[["footerhtml"]]) || is.null(dimnames(x))) {
-        return(y)
-    }
-    footer <- x.attributes[["footerhtml"]]
-    if (isFALSE(attr(y, which = "is.subscripted", exact = TRUE))) {
-        return(structure(y, footerhtml = footer)) # No change to footer if table not subscripted
-    }
-    if (identical(getLength(y), getLength(x))) {
-        return(structure(y, footerhtml = footer)) # No change to footer if table size unchanged
-    }
-    args.as.integer <- convertIndicesToIntegers(evaluated.args, x.attributes = x.attributes)
-    # Only update the footer if not all labels are used in a dimension
-    not.all.labels.used <- mapply(Negate(setequal), args.as.integer, lapply(dim(x), seq_len), SIMPLIFY = TRUE)
-    dimnames.used <- mapply(
-        `[`,
-        dimnames(x)[not.all.labels.used],
-        args.as.integer[not.all.labels.used],
-        SIMPLIFY = FALSE
-    ) |> # Reformat so the list becomes a character vector with each element as comma-separated labels
-        lapply(paste0, collapse = ", ") |>
-        lapply(wrapNamesInParentheses) |>
-        Reduce(f = function(a, b) paste0(a, ", ", b))
-    # Don't update footer if duplicate labels are identified
-    # This can occur for Banner tables
-    duplicate.labels.used <- grepl(pattern = DUPLICATE.LABEL.SUFFIX, x = dimnames.used, fixed = TRUE)
-    if (any(duplicate.labels.used)) { # Try and flatten the QTable and re-attempt
-        flattened.x <- FlattenQTable(x)
-        duplicates.in.flattened.table <- lapply(
-            dimnames(flattened.x),
-            grepl,
-            logical(1L),
-            pattern = DUPLICATE.LABEL.SUFFIX,
-            fixed = TRUE
-        ) |>
-            vapply(any, logical(1L))
-        if (identical(dim(x), dim(flattened.x)) && !any(duplicates.in.flattened.table)) {
-            return(Recall(y, x = flattened.x, evaluated.args = evaluated.args))
-        }
-    }
-    table.name <- x.attributes[["name"]]
-    insertion.point <- findInsertionPointInFooter(footer, name = table.name)
-    updated.footer <- updateFooter(
-        footer = footer,
-        table.name = table.name,
-        insertion.point = insertion.point,
-        insertion.text = dimnames.used
-    )
-    structure(y, footerhtml = updated.footer)
-}
-
-updateFooter <- function(footer, table.name, insertion.point, insertion.text) {
-    if (is.null(footer) || is.null(table.name) || length(insertion.text) != 1L || insertion.point < 0L) {
-        return(footer)
-    }
-    paste0(
-        substr(footer, start = 1L, stop = insertion.point),
-        paste0(insertion.text, collapse = " "),
-        substr(footer, start = insertion.point + 1L, stop = nchar(footer))
-    )
-}
-
-findInsertionPointInFooter <- function(footer, name) {
-    # Use a fixed string match to avoid regex special character issues
-    reg.match <- regexpr(pattern = name, text = footer, fixed = TRUE)
-    if (reg.match == -1L) {
-        return(-1L)
-    }
-    match.length <- attr(reg.match, which = "match.length", exact = TRUE)
-    as.integer(reg.match) + match.length - 1L
 }
 
 updateNameDimensionAttr <- function(y, x.dim) {
@@ -742,30 +656,6 @@ qTableDimnamesMatchQStatInfo <- function(dim.names, q.test.indices)
         return(FALSE)
     differences <- mapply(setdiff, dim.names, saved.qstat.dimnames, SIMPLIFY = FALSE)
     return(all(lengths(differences) == 0L))
-}
-
-convertIndicesToIntegers <- function(args, x.attributes) {
-    dimnames.x <- x.attributes[["dimnames"]]
-    mapply(
-        convertIndexToInteger,
-        args,
-        dimnames.x = dimnames.x,
-        SIMPLIFY = FALSE
-    )
-}
-
-convertIndexToInteger <- function(arg, dimnames.x) {
-    if (isEmptyArg(arg)) {
-        seq_along(dimnames.x)
-    } else if (is.character(arg)) {
-        which(dimnames.x %in% arg)
-    } else if (is.logical(arg)) {
-        which(arg)
-    } else if (is.numeric(arg) && !is.integer(arg)) {
-        as.integer(arg)
-    } else {
-        arg
-    }
 }
 
 findReferencedSlices <- function(evaluated.arg, x.attributes, arg.to.inspect) {

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -87,7 +87,7 @@ test_that("Flatten 3D QTables",
                  colnames(qtable.3D.xtab.multistat))
     expect_equivalent(rownames(qtable.3D.xtab.multistat.flat),
                  rownames(qtable.3D.xtab.multistat))
-    expect_equal(attr(qtable.3D.xtab.multistat.flat, "name"), "table.Age.by.Gender")
+    expect_equal(attr(qtable.3D.xtab.multistat.flat, "name"), "FlattenTable(table.Age.by.Gender)")
 })
 
 test_that("Flatten 4D QTables",

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -79,13 +79,14 @@ expectedSingleTable <- function(tab, ind, drop = NULL) {
     y <- singleSubscriptTable(unclass(tab), ind, drop)
     class(y) <- c("QTable", class(y))
     attr(y, "statistic") <- "Average"
-    attr(y, "name") <- paste0("table.", paste0(dim(tab), collapse = "."))
-    if (!is.array(y) && length(y) > 1L) {
+    orig.name <- paste0("table.", paste0(dim(tab), collapse = "."))
+    attr(y, "original.name") <- orig.name
+    if (!is.array(y) && length(y) > 1L)
         y <- as.array(y)
-    }
-    attr(y, "is.subscripted") <- !identical(dim(y), dim(tab)) ||
-        !identical(dimnames(y), dimnames(tab)) ||
-        !identical(as.vector(y), as.vector(tab))
+    attr(y, "name") <- paste0(orig.name, "[", paste0(ind, collapse = ","), "]")
+    attr(y, "is.subscripted") <- !(identical(dim(y), dim(tab)) &&
+                                   identical(dimnames(y), dimnames(tab)) &&
+                                   identical(as.vector(y), as.vector(tab)))
     y
 }
 doubleSubscriptTable <- function(tab, ind, exact = NULL) {
@@ -99,11 +100,13 @@ expectedDoubleTable <- function(tab, ind, exact = NULL) {
     y <- doubleSubscriptTable(unclass(tab), ind, exact)
     if (!inherits(y, "QTable"))
         class(y) <- c("QTable", class(y))
-    attr(y, "name") <- paste0("table.", paste0(dim(tab), collapse = "."))
+    orig.name <- paste0("table.", paste0(dim(tab), collapse = "."))
+    attr(y, "original.name") <- orig.name
+    attr(y, "name") <- paste0(orig.name, "[[", paste0(ind, collapse = ","), "]]")
     attr(y, "statistic") <- "Average"
-    attr(y, "is.subscripted") <- !identical(dim(y), dim(tab)) ||
-        !identical(dimnames(y), dimnames(tab)) ||
-        !identical(as.vector(y), as.vector(tab))
+    attr(y, "is.subscripted") <- !(identical(dim(y), dim(tab)) &&
+                                   identical(dimnames(y), dimnames(tab)) &&
+                                   identical(as.vector(y), as.vector(tab)))
     y
 }
 
@@ -255,7 +258,8 @@ test_that("drop and exact recognised and used appropriately", {
     expected <- unclass(x.2.1)[, 1, drop = FALSE]
     attr(expected, "statistic") <- "Average"
     class(expected) <- c("QTable", class(expected))
-    attr(expected, "name") <- "table.2.1"
+    attr(expected, "original.name") <- "table.2.1"
+    attr(expected, "name") <- "table.2.1[,1]"
     dimnames(expected) <- unname(dimnames(expected))
     attr(expected, "mapped.dimnames") <- list(Row = LETTERS[1:2], Column = "a")
     attr(expected, "is.subscripted") <- FALSE
@@ -267,8 +271,9 @@ test_that("drop and exact recognised and used appropriately", {
         as.vector(x.2.1),
         class = c("QTable", "integer"),
         statistic = "Average",
-        name = "table.2.1",
+        original.name = "table.2.1",
         names = LETTERS[1:2],
+        name = "table.2.1[,1]",
         statistic = "Average",
         is.subscripted = TRUE
     )
@@ -934,9 +939,9 @@ test_that("DS-3797: Attributes renamed appropriately after subsetting",
     expected.renamed <- paste0("original.",
                                c("dimnets", "dimduplicates", "span",
                                  "basedescriptiontext", "basedescription",
-                                 "questiontypes", "footerhtml"))
+                                 "questiontypes", "footerhtml", "name"))
     expected.basic <- c("dim", "dimnames", "class", "statistic", "questions")
-    expected.modified <- c("QStatisticsTestingInfo", "span", "name", "footerhtml",
+    expected.modified <- c("QStatisticsTestingInfo", "span", "name",
                            "questiontypes", "mapped.dimnames", "is.subscripted")
     expected.custom <- "customAttr"
     attr.names.expected <- c(expected.renamed, expected.basic,
@@ -2157,18 +2162,17 @@ test_that("DS-5046 Mathematical operators don't play nicely with subscripted QTa
 test_that("DS-5072 Ensure subscripted table dimensions/str matches base R", {
     tbls <- readRDS("qTablesWithZStatInCells.rds")
     scalar <- structure(
-        array(0.67, dim = 1L, dimnames = list("Age")),
+        array(0.67, dim = 1L, dimnames = list("variable.name")),
         statistic = "Average",
         class = "QTable",
         questiontypes = "Number",
-        questions = c("Age", "SUMMARY"),
-        name = "Age - Average",
+        questions = c("variable.name", "SUMMARY"),
+        name = "some.table",
         QStatisticsTestingInfo = data.frame(
             significancesignificant = FALSE,
             zstatistic = -.1,
             pcorrected = 0.29
-        ),
-        footerhtml = "Age - Average <br/>N = 1000"
+        )
     )
     single.dim <- Filter(function(x) getDimensionLength(x) == 1L, tbls)[[1L]]
     two.dim <- Filter(function(x) getDimensionLength(x) == 2L && !isMultiStatTable(x), tbls)[[1L]]
@@ -2204,13 +2208,15 @@ test_that("DS-5072 Ensure subscripted table dimensions/str matches base R", {
         setdiff(class(subscripted.scalar), "QTable"),
         class(base.subscripted.scalar)
     )
-    attr(subscripted.scalar, "footerhtml") |> expect_equal(attr(scalar, "footerhtml"))
     # Can be subscripted again
     subscripted.subscripted.scalar <- subscripted.scalar[1L]
+    expect_equal(attr(subscripted.subscripted.scalar, "name"), "some.table[1][1]")
+    attr(subscripted.subscripted.scalar, "name") <- attr(subscripted.scalar, "name")
     expect_true(attr(subscripted.subscripted.scalar, "original.is.subscripted"))
+    expect_equal(attr(subscripted.subscripted.scalar, "original.name"), "some.table[1]")
     attr(subscripted.subscripted.scalar, "original.is.subscripted") <- NULL
-    attr(subscripted.subscripted.scalar, "name") <- "some.table"
-    waldo::compare(subscripted.subscripted.scalar, subscripted.scalar)
+    attr(subscripted.subscripted.scalar, "original.name") <- "some.table"
+    expect_equal(subscripted.subscripted.scalar, subscripted.scalar)
     # 1d
     subscripted.single.dim <- single.dim[1:3]
     base.subscripted.single.dim <- base.single.dim[1:3]
@@ -2419,7 +2425,8 @@ test_that("Multiple stats and dropping", {
         questiontypes = "PickOne",
         original.questiontypes = "PickOne",
         class = c("QTable", "matrix", "array"),
-        name = "some.table",
+        original.name = "some.table",
+        name = "some.table[A,Count]",
         is.subscripted = TRUE,
         mapped.dimnames = list(
             Row = "A",
@@ -2446,7 +2453,8 @@ test_that("Multiple stats and dropping", {
         questiontypes = "PickOne",
         original.questiontypes = "PickOne",
         class = c("QTable", "matrix", "array"),
-        name = "some.table",
+        original.name = "some.table",
+        name = "some.table[c(\"A\", \"C\"),Count]",
         is.subscripted = TRUE,
         mapped.dimnames = list(
             Row = c("A", "C"),
@@ -2487,6 +2495,7 @@ test_that("i and j arguments allowed", {
     )
     ## Able to use do.call(`[`, args), the name is messed up though
     expected.output <- x[LETTERS[1:3], c("Male", "Female")]
+    attr(expected.output, "name") <-  "[c(\"A\", \"B\", \"C\"),c(\"Male\", \"Female\")]"
     expect_equal(
         do.call(`[`, list(x = x, i = LETTERS[1:3], j = c("Male", "Female"))),
         expected.output
@@ -2514,6 +2523,7 @@ test_that("i and j arguments allowed", {
     )
     ## Able to use do.call(`[[`, args), the name is messed up though
     expected.output <- x[[LETTERS[2], "Male"]]
+    attr(expected.output, "name") <-  "[[B,Male]]"
     expect_equal(
         do.call(`[[`, list(x = x, i = LETTERS[2], j = "Male")),
         expected.output
@@ -2550,7 +2560,8 @@ test_that("DS-5314: Extracting more than one stat works", {
         class = c("QTable", "array"),
         questiontypes = "PickOneMulti",
         original.questiontypes = "PickOneMulti",
-        name = "some.table",
+        original.name = "some.table",
+        name = "some.table[c(\"a\", \"c\"),,c(\"A\", \"C\")]",
         QStatisticsTestingInfo = expected.q.stat.info,
         is.subscripted = TRUE,
         mapped.dimnames = list(
@@ -2584,17 +2595,3 @@ test_that("celltext attribute is correctly subscripted in tables", {
     expect_equal(attr(t[3:10], "celltext"), structure(c("c", "d", "e", "f", "g", "h", "i", "j"), dim = c(8L)))
 })
 
-test_that("Can insert subscripting information in footer in correct place", {
-    typical.footer <- "Table Foo Sample size = 10"
-    table.name <- "Table Foo"
-    findInsertionPointInFooter(typical.footer, name = table.name) |> expect_equal(nchar(table.name))
-    # Check reversed
-    name.at.end.footer <- "Sample size = 10 Table Foo"
-    findInsertionPointInFooter(name.at.end.footer, name = table.name) |> expect_equal(nchar(name.at.end.footer))
-    # Check what happens if table name appears multiple times
-    multiple.matches.footer <- "Table Foo Sample size = 10 Table Foo"
-    findInsertionPointInFooter(multiple.matches.footer, name = table.name) |> expect_equal(nchar(table.name))
-    # If table name not found
-    no.match.footer <- "Sample size = 10"
-    findInsertionPointInFooter(no.match.footer, name = table.name) |> expect_equal(-1L)
-})


### PR DESCRIPTION
This reverts commit e8c9eedbd5bef989edd761a670d646b3a37da48d.
