### PR TITLE
SAQ-2077: Insert subscripted dimnames into footerhtml attribute for improved visibility of table contents when printing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: verbs
 Type: Package
 Title: A Grammar for Common Data Manipulations and Summaries
-Version: 0.15.15
+Version: 0.15.16
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: A collection of operations/actions/"verbs" providing an intuitive interface for many common operations (e.g. Sum, First, Average, Maximum, ...) on various inputs/data structures. Created to simplify common user actions in Displayr with a wide variety of inputs.

--- a/R/flatten.R
+++ b/R/flatten.R
@@ -427,7 +427,6 @@ addQTableAttributesToFlattenedTable <- function(flattened.table, x.attr) {
     q.stat.info <- x.attr[["QStatisticsTestingInfo"]]
     x.attr[["QStatisticsTestingInfo"]] <- updateFlattenedDimensionsToQStatInfo(q.stat.info, x.attr[["dimnames"]])
     x.attr[["questiontypes"]] <- updateFlattenedQuestionTypes(x.attr[["questiontypes"]])
-    x.attr[["name"]] <- updateFlattenedName(x.attr[["name"]])
     if (output.is.array) {
         q.stat.info.names <- names(x.attr[["QStatisticsTestingInfo"]])
         dim.names.names <- c("Row", "Column")[c("Row", "Column") %in% q.stat.info.names]
@@ -437,11 +436,6 @@ addQTableAttributesToFlattenedTable <- function(flattened.table, x.attr) {
     }
     mostattributes(flattened.table) <- x.attr
     flattened.table
-}
-
-updateFlattenedName <- function(x) {
-    if (is.null(x)) return(x)
-    paste0("FlattenTable(", x, ")")
 }
 
 updateFlattenedDimensionsToQStatInfo <- function(q.stat.info, new.dimnames) {

--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -349,7 +349,7 @@ updateFooterIfNecessary <- function(y, x, evaluated.args) {
 }
 
 setFooterAttributeToTable <- function(x, footer) {
-    structure(x, footerhtml = footer)
+    structure(x, subscripted.footerhtml = footer)
 }
 
 updateFooter <- function(footer, table.name, insertion.point, insertion.text) {
@@ -389,17 +389,19 @@ updateAttributeNames <- function(y) {
     qtable.attr.names <- setdiff(eval(formals(IsQTableAttribute)$qtable.attrs),
                                  DONT.RENAME.ATTRS)
     names.needing.update <- IsQTableAttribute(attr.names, qtable.attr.names) &
-                            !isBasicAttribute(attr.names)
+        !isBasicAttribute(attr.names)
     names(attributes(y))[names.needing.update] <- paste0("original.", attr.names[names.needing.update])
     y
 }
 
 updateIsSubscriptedAttr <- function(y, x) {
     is.subscripted.attr <- attr(y, "is.subscripted")
-    if (isTRUE(is.subscripted.attr)) return(y)
-    attr(y, "is.subscripted") <- !(identical(dim(y), dim(x)) &&
-                                   identical(dimnames(y), dimnames(x)) &&
-                                   identical(as.vector(y), as.vector(x)))
+    if (isTRUE(is.subscripted.attr)) {
+        return(y)
+    }
+    attr(y, "is.subscripted") <- !identical(dim(y), dim(x)) ||
+        !identical(dimnames(y), dimnames(x)) ||
+        !identical(as.vector(y), as.vector(x))
     y
 }
 

--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -303,10 +303,10 @@ updateFooterIfNecessary <- function(y, x, evaluated.args) {
     }
     footer <- x.attributes[["footerhtml"]]
     if (isFALSE(attr(y, which = "is.subscripted", exact = TRUE))) {
-        return(structure(y, footerhtml = footer)) # No change to footer if table not subscripted
+        return(setFooterAttributeToTable(y, footer = footer)) # No change to footer if table not subscripted
     }
     if (identical(getLength(y), getLength(x))) {
-        return(structure(y, footerhtml = footer)) # No change to footer if table size unchanged
+        return(setFooterAttributeToTable(y, footer = footer)) # No change to footer if table size unchanged
     }
     args.as.integer <- convertIndicesToIntegers(evaluated.args, x.attributes = x.attributes)
     # Only update the footer if not all labels are used in a dimension
@@ -345,7 +345,11 @@ updateFooterIfNecessary <- function(y, x, evaluated.args) {
         insertion.point = insertion.point,
         insertion.text = dimnames.used
     )
-    structure(y, footerhtml = updated.footer)
+    setFooterAttributeToTable(y, footer = updated.footer)
+}
+
+setFooterAttributeToTable <- function(x, footer) {
+    structure(x, footerhtml = footer)
 }
 
 updateFooter <- function(footer, table.name, insertion.point, insertion.text) {

--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -20,7 +20,6 @@
     if (input.is.not.array)
         x <- as.array(x)
 
-    DUPLICATE.LABEL.SUFFIX  <- "_@_"
     x <- deduplicateQTableLabels(x, DUPLICATE.LABEL.SUFFIX)
 
     x.dim <- dim(x)
@@ -50,7 +49,6 @@
     # Update Attributes here
     y <- updateTableAttributes(y, x, called.args, evaluated.args, drop = drop,
                                missing.names, DUPLICATE.LABEL.SUFFIX)
-    y <- updateNameAttribute(y, attr(x, "name"), called.args, "[")
     throwWarningIfDuplicateLabels(x, evaluated.args, sep = DUPLICATE.LABEL.SUFFIX)
     y <- removeDeduplicationSuffixFromLabels(y, DUPLICATE.LABEL.SUFFIX)
 
@@ -62,6 +60,8 @@
 
     y
 }
+
+DUPLICATE.LABEL.SUFFIX  <- "_@_"
 
 #' @importFrom flipU StopForUserError
 #' @export
@@ -82,7 +82,6 @@
     if (input.is.not.array)
         x <- as.array(x)
 
-    DUPLICATE.LABEL.SUFFIX  <- "_@_"
     x <- deduplicateQTableLabels(x, DUPLICATE.LABEL.SUFFIX)
 
     x.dim <- dim(x)
@@ -120,7 +119,6 @@
 
     # Update Attributes here
     y <- updateTableAttributes(y, x, called.args, evaluated.args, drop = TRUE, missing.names)
-    y <- updateNameAttribute(y, attr(x, "name"), called.args, "[[")
     y <- removeDeduplicationSuffixFromLabels(y, DUPLICATE.LABEL.SUFFIX)
     if (missing.names)
         y <- unname(y)
@@ -137,12 +135,8 @@ dropTableToVector <- function(x) {
     x
 }
 
-updateNameAttribute <- function(y, original.name, called.args, subscript.type = "[")
-{
-    end.char <- if (subscript.type == "[") "]" else "]]"
-    subscript.args <- paste0(subscript.type, paste(as.character(called.args), collapse = ","), end.char)
-    attr(y, "name") <- paste0(original.name, subscript.args)
-    y
+updateNameAttribute <- function(y, original.name) {
+    structure(y, name = original.name)
 }
 
 # named arguments to [ or [[ are the input itself (x) and i and j references
@@ -239,7 +233,7 @@ throwErrorOnlyNamed <- function(named.arg, function.name) {
                      sQuote(function.name))
 }
 
-isBasicAttribute <- function(attribute.names, basic.attr = c("dim", "names", "dimnames", "class")) {
+isBasicAttribute <- function(attribute.names, basic.attr = c("dim", "names", "dimnames", "class", "name")) {
     attribute.names %in% basic.attr
 }
 
@@ -275,12 +269,104 @@ updateTableAttributes <- function(y, x, called.args, evaluated.args, drop = TRUE
     x.attributes <- updateQuestionTypesIfDoesntMatchDim(x.attributes)
     y <- updateQuestionTypesAttr(y, x.attributes, evaluated.args, drop = drop)
     y <- updateQStatisticsTestingInfo(y, x.attributes, evaluated.args, original.missing.names, sep)
+    y <- updateNameAttribute(y, x.attributes[["name"]])
     y <- updateNameDimensionAttr(y, x.attributes[["dim"]])
     y <- updateSpanIfNecessary(y, x.attributes, evaluated.args)
     y <- updateIsSubscriptedAttr(y, x)
+    y <- updateFooterIfNecessary(y, x, evaluated.args)
     y <- updateCellText(y, x.attributes, evaluated.args)
     y <- keepMappedDimnames(y)
     y
+}
+
+#' Should convert a single string into a string wrapped in parantheses
+#' If an empty string (no characters) or NA is provided, returns NULL
+#' @noRd
+wrapNamesInParentheses <- function(x) {
+    if (!nzchar(x) || is.na(x)) {
+        return(NULL)
+    }
+    paste0("(", x, ")")
+}
+
+getLength <- function(x) {
+    if (!is.null(dim(x))) {
+        return(prod(dim(x)) |> as.integer())
+    }
+    length(x)
+}
+
+updateFooterIfNecessary <- function(y, x, evaluated.args) {
+    x.attributes <- attributes(x)
+    if (is.null(x.attributes[["footerhtml"]]) || is.null(dimnames(x))) {
+        return(y)
+    }
+    footer <- x.attributes[["footerhtml"]]
+    if (isFALSE(attr(y, which = "is.subscripted", exact = TRUE))) {
+        return(structure(y, footerhtml = footer)) # No change to footer if table not subscripted
+    }
+    if (identical(getLength(y), getLength(x))) {
+        return(structure(y, footerhtml = footer)) # No change to footer if table size unchanged
+    }
+    args.as.integer <- convertIndicesToIntegers(evaluated.args, x.attributes = x.attributes)
+    # Only update the footer if not all labels are used in a dimension
+    not.all.labels.used <- mapply(Negate(setequal), args.as.integer, lapply(dim(x), seq_len), SIMPLIFY = TRUE)
+    dimnames.used <- mapply(
+        `[`,
+        dimnames(x)[not.all.labels.used],
+        args.as.integer[not.all.labels.used],
+        SIMPLIFY = FALSE
+    ) |> # Reformat so the list becomes a character vector with each element as comma-separated labels
+        lapply(paste0, collapse = ", ") |>
+        lapply(wrapNamesInParentheses) |>
+        Reduce(f = function(a, b) paste0(a, ", ", b))
+    # Don't update footer if duplicate labels are identified
+    # This can occur for Banner tables
+    duplicate.labels.used <- grepl(pattern = DUPLICATE.LABEL.SUFFIX, x = dimnames.used, fixed = TRUE)
+    if (any(duplicate.labels.used)) { # Try and flatten the QTable and re-attempt
+        flattened.x <- FlattenQTable(x)
+        duplicates.in.flattened.table <- lapply(
+            dimnames(flattened.x),
+            grepl,
+            logical(1L),
+            pattern = DUPLICATE.LABEL.SUFFIX,
+            fixed = TRUE
+        ) |>
+            vapply(any, logical(1L))
+        if (identical(dim(x), dim(flattened.x)) && !any(duplicates.in.flattened.table)) {
+            return(Recall(y, x = flattened.x, evaluated.args = evaluated.args))
+        }
+    }
+    table.name <- x.attributes[["name"]]
+    insertion.point <- findInsertionPointInFooter(footer, name = table.name)
+    updated.footer <- updateFooter(
+        footer = footer,
+        table.name = table.name,
+        insertion.point = insertion.point,
+        insertion.text = dimnames.used
+    )
+    structure(y, footerhtml = updated.footer)
+}
+
+updateFooter <- function(footer, table.name, insertion.point, insertion.text) {
+    if (is.null(footer) || is.null(table.name) || length(insertion.text) != 1L || insertion.point < 0L) {
+        return(footer)
+    }
+    paste0(
+        substr(footer, start = 1L, stop = insertion.point),
+        paste0(insertion.text, collapse = " "),
+        substr(footer, start = insertion.point + 1L, stop = nchar(footer))
+    )
+}
+
+findInsertionPointInFooter <- function(footer, name) {
+    # Use a fixed string match to avoid regex special character issues
+    reg.match <- regexpr(pattern = name, text = footer, fixed = TRUE)
+    if (reg.match == -1L) {
+        return(-1L)
+    }
+    match.length <- attr(reg.match, which = "match.length", exact = TRUE)
+    as.integer(reg.match) + match.length - 1L
 }
 
 updateNameDimensionAttr <- function(y, x.dim) {
@@ -656,6 +742,30 @@ qTableDimnamesMatchQStatInfo <- function(dim.names, q.test.indices)
         return(FALSE)
     differences <- mapply(setdiff, dim.names, saved.qstat.dimnames, SIMPLIFY = FALSE)
     return(all(lengths(differences) == 0L))
+}
+
+convertIndicesToIntegers <- function(args, x.attributes) {
+    dimnames.x <- x.attributes[["dimnames"]]
+    mapply(
+        convertIndexToInteger,
+        args,
+        dimnames.x = dimnames.x,
+        SIMPLIFY = FALSE
+    )
+}
+
+convertIndexToInteger <- function(arg, dimnames.x) {
+    if (isEmptyArg(arg)) {
+        seq_along(dimnames.x)
+    } else if (is.character(arg)) {
+        which(dimnames.x %in% arg)
+    } else if (is.logical(arg)) {
+        which(arg)
+    } else if (is.numeric(arg) && !is.integer(arg)) {
+        as.integer(arg)
+    } else {
+        arg
+    }
 }
 
 findReferencedSlices <- function(evaluated.arg, x.attributes, arg.to.inspect) {

--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -310,7 +310,15 @@ updateFooterIfNecessary <- function(y, x, evaluated.args) {
     }
     args.as.integer <- convertIndicesToIntegers(evaluated.args, x.attributes = x.attributes)
     # Only update the footer if not all labels are used in a dimension
-    not.all.labels.used <- mapply(Negate(setequal), args.as.integer, lapply(dim(x), seq_len), SIMPLIFY = TRUE)
+    # The above will convert any subscript arguments to the integer indices used. This is compared to the
+    # full set of indices for each dimension to determine if all labels are used. Updates footer only if
+    # the sets of indices not equal
+    not.all.labels.used <- mapply(
+        Negate(setequal),  # Determine if integer indices are not the same set (order doesnt matter)
+        args.as.integer,
+        lapply(dim(x), seq_len), # Generate the set of indices for the original table
+        SIMPLIFY = TRUE
+    )
     dimnames.used <- mapply(
         `[`,
         dimnames(x)[not.all.labels.used],

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -87,7 +87,7 @@ test_that("Flatten 3D QTables",
                  colnames(qtable.3D.xtab.multistat))
     expect_equivalent(rownames(qtable.3D.xtab.multistat.flat),
                  rownames(qtable.3D.xtab.multistat))
-    expect_equal(attr(qtable.3D.xtab.multistat.flat, "name"), "FlattenTable(table.Age.by.Gender)")
+    expect_equal(attr(qtable.3D.xtab.multistat.flat, "name"), "table.Age.by.Gender")
 })
 
 test_that("Flatten 4D QTables",

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -2311,6 +2311,39 @@ for (test in duplicate.labels.tests)
         suppressWarnings(eval(test.code))
     }))
 
+test_that("SAQ-2077: Duplicate labels are not present in footer", {
+    # Occurrences of duplicates in dimnames don't appear in footerhtml
+    duplicate.1d.table <- duplicate.labels.tests[[1]][["input"]]
+    attr(duplicate.1d.table, "name") <- "Exercise frequency"
+    subscripted.table <- duplicate.1d.table[2:4, 1]
+    names(subscripted.table) |> expect_equal(c("Less often", "Never", "Never_@_1"))
+    attr(subscripted.table, "subscripted.footerhtml") |>
+        startsWith(prefix = "Exercise frequency(Less often, Never), (%) SUMMARY<br />") |>
+        expect_true()
+    attr(subscripted.table, "footerhtml") |> expect_null()
+    attr(duplicate.1d.table, "footerhtml") |>
+        startsWith(prefix = "Exercise frequency SUMMARY<br />") |>
+        expect_true()
+    # Flattened Table disambiguation
+    duplicate.2d.table.with.spans <- duplicate.labels.tests[[3]][["input"]]
+    attr(duplicate.2d.table.with.spans, "name") <- "Preferred cola small by BANNER2"
+    subscripted.banner.table <- duplicate.2d.table.with.spans[c("Coke", "Pepsi"), c(1:2, 4:5), 1]
+    colnames(subscripted.banner.table) |>
+        expect_equal(rep(c("Low", "High"), 2L))
+    attr(subscripted.banner.table, "subscripted.footerhtml") |>
+        startsWith(
+            prefix = paste0(
+                "Preferred cola small by BANNER2(Coke, Pepsi), ",
+                "(Male - Low, Male - High, Female - Low, Female - High), ",
+                "(Column %)<br />"
+            )
+        ) |>
+        expect_true()
+    attr(duplicate.2d.table.with.spans, "footerhtml") |>
+        startsWith(prefix = "Preferred cola small by BANNER2<br />") |>
+        expect_true()
+})
+
 test_that("DS-5090, DS-5135: Warning thrown if duplicate labels present in input",
 {
     input <- duplicate.labels.tests[[4]]$input

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -925,8 +925,7 @@ test_that("Span attributes retained properly", {
 env <- new.env()
 source(system.file("tests", "QTables.R", package = "verbs"), local = env)
 
-test_that("DS-3797: Attributes renamed appropriately after subsetting",
-{
+test_that("DS-3797: Attributes renamed appropriately after subsetting", {
     tbl <- env$qTable.2D
     attr(tbl, "customAttr") <- "FooBar"
     out <- tbl[1:2, 1:2]
@@ -936,7 +935,7 @@ test_that("DS-3797: Attributes renamed appropriately after subsetting",
                                  "basedescriptiontext", "basedescription",
                                  "questiontypes", "footerhtml"))
     expected.basic <- c("dim", "dimnames", "class", "statistic", "questions")
-    expected.modified <- c("QStatisticsTestingInfo", "span", "name", "footerhtml",
+    expected.modified <- c("QStatisticsTestingInfo", "span", "name", "subscripted.footerhtml",
                            "questiontypes", "mapped.dimnames", "is.subscripted")
     expected.custom <- "customAttr"
     attr.names.expected <- c(expected.renamed, expected.basic,
@@ -2204,7 +2203,7 @@ test_that("DS-5072 Ensure subscripted table dimensions/str matches base R", {
         setdiff(class(subscripted.scalar), "QTable"),
         class(base.subscripted.scalar)
     )
-    attr(subscripted.scalar, "footerhtml") |> expect_equal(attr(scalar, "footerhtml"))
+    attr(subscripted.scalar, "subscripted.footerhtml") |> expect_equal(attr(scalar, "footerhtml"))
     # Can be subscripted again
     subscripted.subscripted.scalar <- subscripted.scalar[1L]
     expect_true(attr(subscripted.subscripted.scalar, "original.is.subscripted"))


### PR DESCRIPTION
Reimplements https://github.com/Displayr/verbs/pull/126 but with two changes.
1. The `footerhtml` attribute isn't saved in the same location when a table is subscripted. That is, the table caption is not retained when a table is subscripted.
2. The footer for a subscribed table is saved in a new attribute called `"subscripted.footerhtml"`. This footer is the same as the original footer but does the same transformation that was implemented in https://github.com/Displayr/verbs/pull/126