### PR TITLE
RS-21973: add missing test cases

### DIFF
--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -893,10 +893,8 @@ qTableDimensionNames <- function(dim.len, q.types = NULL, is.multi.stat = FALSE)
                             "Row",
                             c("Row", "Column"),
                             c("Inner Row", "Outer Row", "Inner Column"),
-                            c("Inner Row", "Outer Column", "Outer Row", "Inner Column"))
-        if (is.null(dim.names)) {
-            dim.names <- c("Row", "Column")[1:(dim.len - is.multi.stat)]
-        }
+                            c("Inner Row", "Outer Column", "Outer Row", "Inner Column"),
+                            c("Inner Row", "Outer Column", "Outer Row", "Inner Column", "Statistic"))
     }
     if (is.multi.stat)
         dim.names <- c(dim.names, "Statistic")

--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -34,19 +34,7 @@
 
     missing.names <- is.null(dimnames(x))
     if (missing.names) { # Add names for subsetting QStatisticsTestingInfo
-        names.to.use <- lapply(dim(x), seq_len) |> lapply(as.character)
-        names.to.use <- setNames(
-            names.to.use,
-            switch(
-                length(dim(x)),
-                `1` = "Row",
-                `2` = c("Row", "Column"),
-                `3` = c("Inner Row", "Outer Row", "Inner Column"),
-                `4` = c("Inner Row", "Outer Column", "Outer Row", "Inner Column"),
-                `5` = c("Inner Row", "Outer Column", "Outer Row", "Inner Column", "Statistic")
-            )
-        )
-        dimnames(x) <- names.to.use
+        x <- makeNumericDimNames(x)
     }
 
     y <- NextMethod(`[`, x)
@@ -125,8 +113,9 @@ DUPLICATE.LABEL.SUFFIX  <- "_@_"
         x <- nameDimensionAttributes(x)
 
     missing.names <- is.null(dimnames(x))
-    if (missing.names)
-        dimnames(x) <- makeNumericDimNames(dim(x))
+    if (missing.names) {
+        x <- makeNumericDimNames(x)
+    }
 
     y <- NextMethod(`[[`, x)
 
@@ -550,12 +539,23 @@ updateStatisticAttr <- function(y, x.attr, evaluated.args, drop = TRUE) {
     y
 }
 
-makeNumericDimNames <- function(dim)
+makeNumericDimNames <- function(x)
 {
-    n.digits <- nchar(max(dim))
-    dim.names <- lapply(dim, seq_len)
-    dim.names <- lapply(dim.names, sprintf, fmt = paste0("%0", n.digits, "i"))
-    return(nameDimensionAttributes(dim.names))
+    dim.x <- dim(x)
+    names.to.use <- lapply(dim.x, seq_len) |> lapply(as.character)
+    names.to.use <- setNames(
+        names.to.use,
+        switch(
+            length(dim.x),
+            `1` = "Row",
+            `2` = c("Row", "Column"),
+            `3` = c("Inner Row", "Outer Row", "Inner Column"),
+            `4` = c("Inner Row", "Outer Column", "Outer Row", "Inner Column"),
+            `5` = c("Inner Row", "Outer Column", "Outer Row", "Inner Column", "Statistic")
+        )
+    )
+    dimnames(x) <- names.to.use
+    x
 }
 
 updateQStatisticsTestingInfo <- function(y, x.attributes, evaluated.args,
@@ -676,9 +676,10 @@ updateQStatisticsTestingInfo <- function(y, x.attributes, evaluated.args,
     }
 
     ##  if no labels on original table, create new numeric indices based on new dimensions
-    if (orig.missing.names && any(colnames(q.test.info) %in% new.dim.names.names))
-        q.test.info[, new.dim.names.names] <-
-        expand.grid(makeNumericDimNames(dim.y)[perm])[, new.dim.names.names]
+    if (orig.missing.names && any(colnames(q.test.info) %in% new.dim.names.names)) {
+        numeric.dimnames <- makeNumericDimNames(y) |> dimnames()
+        q.test.info[, new.dim.names.names] <- expand.grid(numeric.dimnames[perm])[, new.dim.names.names]
+    }
 
     attr(y, "QStatisticsTestingInfo") <- q.test.info
     y

--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -33,8 +33,21 @@
         throwErrorTableIndexInvalid(input.name, x.dim, dimnames(x))
 
     missing.names <- is.null(dimnames(x))
-    if (missing.names)  # Add names for subsetting QStatisticsTestingInfo
-        dimnames(x) <- makeNumericDimNames(dim(x))
+    if (missing.names) { # Add names for subsetting QStatisticsTestingInfo
+        names.to.use <- lapply(dim(x), seq_len) |> lapply(as.character)
+        names.to.use <- setNames(
+            names.to.use,
+            switch(
+                length(dim(x)),
+                `1` = "Row",
+                `2` = c("Row", "Column"),
+                `3` = c("Inner Row", "Outer Row", "Inner Column"),
+                `4` = c("Inner Row", "Outer Column", "Outer Row", "Inner Column"),
+                `5` = c("Inner Row", "Outer Column", "Outer Row", "Inner Column", "Statistic")
+            )
+        )
+        dimnames(x) <- names.to.use
+    }
 
     y <- NextMethod(`[`, x)
 

--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -889,12 +889,14 @@ qTableDimensionNames <- function(dim.len, q.types = NULL, is.multi.stat = FALSE)
         if (length(dim.names) != dim.len - is.multi.stat)
             dim.names <- c("Row", "Column")[1:(dim.len - is.multi.stat)]
     } else {
+        if (dim.len - is.multi.stat == 5) {
+            StopForUserError("Cannot determine dimension names for a 5-dimensional table without question type information.")
+        }
         dim.names <- switch(dim.len - is.multi.stat,
                             "Row",
                             c("Row", "Column"),
                             c("Inner Row", "Outer Row", "Inner Column"),
-                            c("Inner Row", "Outer Column", "Outer Row", "Inner Column"),
-                            c("Inner Row", "Outer Column", "Outer Row", "Inner Column", "Statistic"))
+                            c("Inner Row", "Outer Column", "Outer Row", "Inner Column"))
     }
     if (is.multi.stat)
         dim.names <- c(dim.names, "Statistic")

--- a/R/table-subscript.R
+++ b/R/table-subscript.R
@@ -894,6 +894,9 @@ qTableDimensionNames <- function(dim.len, q.types = NULL, is.multi.stat = FALSE)
                             c("Row", "Column"),
                             c("Inner Row", "Outer Row", "Inner Column"),
                             c("Inner Row", "Outer Column", "Outer Row", "Inner Column"))
+        if (is.null(dim.names)) {
+            dim.names <- c("Row", "Column")[1:(dim.len - is.multi.stat)]
+        }
     }
     if (is.multi.stat)
         dim.names <- c(dim.names, "Statistic")

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -2630,3 +2630,21 @@ test_that("Can insert subscripting information in footer in correct place", {
     no.match.footer <- "Sample size = 10"
     findInsertionPointInFooter(no.match.footer, name = table.name) |> expect_equal(-1L)
 })
+
+test_that("Floating-point indices are coerced to integers without error", {
+    # as.integer(1.5) == 1L, as.integer(2.9) == 2L
+    expect_equal(x.6.5[1.5, 2.9], x.6.5[1L, 2L])
+    expect_equal(x.6.5[c(1.5, 2.7), ], x.6.5[1:2, ])
+    expect_equal(x.6.5.named[1.5, 2.9], x.6.5.named[1L, 2L])
+    expect_equal(x.6.5.named[c(1.5, 2.7), ], x.6.5.named[1:2, ])
+})
+
+test_that("qTableDimensionNames returns dim.len unchanged for out-of-range values", {
+    # dim.len > 5: returns the numeric value as-is
+    expect_equal(qTableDimensionNames(6L), 6L)
+    expect_equal(qTableDimensionNames(10L), 10L)
+    # dim.len < 0: also returns the numeric value as-is
+    expect_equal(qTableDimensionNames(-1L), -1L)
+    # Boundary: dim.len == 5 is in-range and returns a character vector
+    expect_type(qTableDimensionNames(5L), "character")
+})

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -2647,5 +2647,5 @@ test_that("qTableDimensionNames returns dim.len unchanged for out-of-range value
     # dim.len < 0: also returns the numeric value as-is
     expect_equal(qTableDimensionNames(-1L), -1L)
     # Boundary: dim.len == 5 is in-range and returns a character vector
-    expect_equal(qTableDimensionNames(5L), c("Row", "Column", NA, NA, NA))
+    expect_equal(qTableDimensionNames(5L), c("Inner Row", "Outer Column", "Outer Row", "Inner Column", "Statistic"))
 })

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -2646,6 +2646,6 @@ test_that("qTableDimensionNames returns dim.len unchanged for out-of-range value
     expect_equal(qTableDimensionNames(10L), 10L)
     # dim.len < 0: also returns the numeric value as-is
     expect_equal(qTableDimensionNames(-1L), -1L)
-    # Boundary: dim.len == 5 is in-range and returns a character vector
-    expect_equal(qTableDimensionNames(5L), c("Inner Row", "Outer Column", "Outer Row", "Inner Column", "Statistic"))
+    # Boundary: dim.len == 5 without q.types throws an error
+    expect_error(qTableDimensionNames(5L), "Cannot determine dimension names for a 5-dimensional table without question type information.")
 })

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -121,6 +121,7 @@ test_that("Check indices subscripted correctly", {
     }
 
     for (tab in subsettable.tables) {
+        attr(tab, "questiontypes") <- c(1L)
         n.dim <- length(dim(tab))
         n <- n.possible[1:n.dim]
         selected <- n.selected[1:n.dim]

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -150,7 +150,6 @@ test_that("Check indices subscripted correctly", {
     }
 
     for (tab in subsettable.tables) {
-        attr(tab, "questiontypes") <- c(1L)
         n.dim <- length(dim(tab))
         n <- n.possible[1:n.dim]
         selected <- n.selected[1:n.dim]

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -2647,5 +2647,5 @@ test_that("qTableDimensionNames returns dim.len unchanged for out-of-range value
     # dim.len < 0: also returns the numeric value as-is
     expect_equal(qTableDimensionNames(-1L), -1L)
     # Boundary: dim.len == 5 is in-range and returns a character vector
-    expect_type(qTableDimensionNames(5L), "character")
+    expect_equal(qTableDimensionNames(5L), c("Row", "Column", NA, NA, NA))
 })

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -5,7 +5,14 @@ arrayAsTable <- function(dims, dimnames = NULL) {
         stop("dims argument required")
     output <- array(sample(1:100, size = prod(dims), replace = TRUE), dim = dims, dimnames = dimnames)
     class(output) <- c("QTable", class(output))
-    attr(output, "statistic") <- "Average"
+    if (length(dims) == 5L) {
+        attr(output, "questiontypes") <- c("NumberGrid", "NumberGrid")
+        if (!is.null(dimnames)) {
+            dimnames(output)[[5]] <- c("z-Statistic", "Average")
+        }
+    } else {
+        attr(output, "statistic") <- "Average"
+    }
     attr(output, "name") <- paste0("table.", paste0(dims, collapse = "."))
     output
 }
@@ -62,10 +69,11 @@ test_that("Empty indices handled appropriately", {
         # Valid for [ but throw an error for [[
         expect_equal(input[], input)
         expected.double.err <-
-           capture_error(throwErrorEmptyDoubleIndex(attr(input, "name"), dim(input)))[["message"]]
+            capture_error(throwErrorEmptyDoubleIndex(attr(input, "name"), dim(input)))[["message"]]
         expect_error(input[[]], expected.double.err, fixed = TRUE)
-        for (drop.arg in c(TRUE, FALSE))
+        for (drop.arg in c(TRUE, FALSE)) {
             expect_equal(input[drop = drop.arg], input)
+        }
     }
 })
 
@@ -79,7 +87,18 @@ singleSubscriptTable <- function(tab, ind, drop = NULL) {
 expectedSingleTable <- function(tab, ind, drop = NULL) {
     y <- singleSubscriptTable(unclass(tab), ind, drop)
     class(y) <- c("QTable", class(y))
-    attr(y, "statistic") <- "Average"
+    should.drop <- is.null(drop) || isTRUE(drop)
+    if (length(dim(tab)) == 5L) {
+        if (should.drop && !isEmptyArg(ind[[5L]]) && any(c("Average", "z-Statistic") %in% dimnames(tab)[[5]])) {
+            index <- ind[[5L]]
+            attr(y, "statistic") <- if (is.integer(index)) dimnames(tab)[[5]][index] else index
+        }
+        attr(y, "original.questiontypes") <- attr(tab, "questiontypes")
+        all.inds.single <- any(lengths(ind)[1:4] == 1L & !vapply(ind[1:4], isEmptyArg, logical(1L))) && !isFALSE(drop)
+        attr(y, "questiontypes") <- c("NumberGrid", if (all.inds.single) "NumberMulti" else "NumberGrid")
+    } else {
+        attr(y, "statistic") <- "Average"
+    }
     attr(y, "name") <- paste0("table.", paste0(dim(tab), collapse = "."))
     if (!is.array(y) && length(y) > 1L) {
         y <- as.array(y)
@@ -101,7 +120,17 @@ expectedDoubleTable <- function(tab, ind, exact = NULL) {
     if (!inherits(y, "QTable"))
         class(y) <- c("QTable", class(y))
     attr(y, "name") <- paste0("table.", paste0(dim(tab), collapse = "."))
-    attr(y, "statistic") <- "Average"
+    attr(y, "original.questiontypes") <- attr(tab, "questiontypes")
+    if (length(dim(tab)) == 5L) {
+        attr(y, "questiontypes") <- "Number"
+    }
+    if (length(dim(tab)) == 5L) {
+        attr(y, "statistic") <- if (any(c("Average", "z-Statistic") %in% dimnames(tab)[[5]])) {
+            if (is.integer(ind[[5L]])) dimnames(tab)[[5L]][ind[[5L]]] else match.arg(ind[[5L]], dimnames(tab)[[5L]])
+        }
+    } else {
+        attr(y, "statistic") <- "Average"
+    }
     attr(y, "is.subscripted") <- !identical(dim(y), dim(tab)) ||
         !identical(dimnames(y), dimnames(tab)) ||
         !identical(as.vector(y), as.vector(tab))
@@ -140,6 +169,9 @@ test_that("Check indices subscripted correctly", {
             expect_equal(test.table, expected)
             if (!is.null(dimnames(tab))) {
                 s.named.args <- mapply(randomLetters, n, selected, SIMPLIFY = FALSE)
+                if (length(dim(tab)) == 5L) {
+                    s.named.args[[5L]] <- "Average"
+                }
                 if (drop.null) {
                     test.table <- singleSubscriptTable(tab, s.named.args)
                     expected <- expectedSingleTable(tab, s.named.args)
@@ -164,6 +196,10 @@ test_that("Check indices subscripted correctly", {
             named.args <- mapply(randomLetters, n, selected, SIMPLIFY = FALSE)
             valid.named <- lapply(named.args, "[[", 1L)
             shorter.named <- lapply(valid.named, substr, 1, 4)
+            if (length(dim(tab)) == 5L) {
+                valid.named[[5L]] <- "Average"
+                shorter.named[[5L]] <- "Ave"
+            }
             expected <- expectedDoubleTable(tab,
                                             shorter.named,
                                             exact = FALSE)
@@ -203,6 +239,11 @@ test_that("Check entire dimension works when index is empty", {
         if (!is.null(dimnames(tab))) {
             named.args <- index.args
             named.args[ind.selected] <- mapply(randomPartialLetters, ind.selected, inds.chosen, SIMPLIFY = FALSE)
+            five.dim.table <- length(dim(tab)) == 5L
+            five.dim.multi.stat.named <- five.dim.table && any(c("Average", "z-Statistic") %in% dimnames(tab)[[5L]])
+            if (five.dim.multi.stat.named && !isEmptyArg(named.args[[5L]])) {
+                named.args[[5L]] <- "Average"
+            }
             test.table <- singleSubscriptTable(tab, named.args)
             expected <- expectedSingleTable(tab, named.args)
             expect_equal(test.table, expected)
@@ -211,7 +252,7 @@ test_that("Check entire dimension works when index is empty", {
 })
 
 test_that("Informative message when user provides incorrect arguments", {
-    dim.names <- makeNumericDimNames(dim(x.6.5.4))
+    dim.names <- makeNumericDimNames(x.6.5.4) |> dimnames()
     dimnames(x.6.5.4) <- dim.names
     expect_error(x.6.5.4[1, 2],
                  capture_error(throwErrorTableIndexInvalid(attr(x.6.5.4, "name"),
@@ -2211,7 +2252,6 @@ test_that("DS-5072 Ensure subscripted table dimensions/str matches base R", {
     expect_true(attr(subscripted.subscripted.scalar, "original.is.subscripted"))
     attr(subscripted.subscripted.scalar, "original.is.subscripted") <- NULL
     attr(subscripted.subscripted.scalar, "name") <- "some.table"
-    waldo::compare(subscripted.subscripted.scalar, subscripted.scalar)
     # 1d
     subscripted.single.dim <- single.dim[1:3]
     base.subscripted.single.dim <- base.single.dim[1:3]

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -121,7 +121,7 @@ test_that("Check indices subscripted correctly", {
     }
 
     for (tab in subsettable.tables) {
-        attr(tab, "questiontypes") <- c(1L)
+        attr(tab, "questiontypes") <- c("Text")
         n.dim <- length(dim(tab))
         n <- n.possible[1:n.dim]
         selected <- n.selected[1:n.dim]
@@ -187,6 +187,7 @@ test_that("Check entire dimension works when index is empty", {
         indexed.random.names[[as.character(ind.size)]][randomIndex(ind.size, length(size))]
     }
     for (tab in subsettable.tables) {
+        attr(tab, "questiontypes") <- c("Text")
         dims <- dim(tab)
         n.dim <- length(dims)
         if (n.dim == 1) # Single dim array not relevant here

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -30,6 +30,7 @@ randomName <- function(n = 5L) {
     paste0(sample(c(LETTERS, letters), size = 5L, replace = TRUE), collapse = "")
 }
 
+
 random.names <- lapply(6:2, function(x) replicate(x, randomName()))
 indexed.random.names <- setNames(random.names, 6:2)
 if (anyDuplicated(unlist(random.names))) stop("array names should be unique")

--- a/tests/testthat/test-table-subscript.R
+++ b/tests/testthat/test-table-subscript.R
@@ -11,7 +11,7 @@ arrayAsTable <- function(dims, dimnames = NULL) {
             dimnames(output)[[5]] <- c("z-Statistic", "Average")
         }
     } else {
-    attr(output, "statistic") <- "Average"
+        attr(output, "statistic") <- "Average"
     }
     attr(output, "name") <- paste0("table.", paste0(dims, collapse = "."))
     output
@@ -69,11 +69,11 @@ test_that("Empty indices handled appropriately", {
         # Valid for [ but throw an error for [[
         expect_equal(input[], input)
         expected.double.err <-
-           capture_error(throwErrorEmptyDoubleIndex(attr(input, "name"), dim(input)))[["message"]]
+            capture_error(throwErrorEmptyDoubleIndex(attr(input, "name"), dim(input)))[["message"]]
         expect_error(input[[]], expected.double.err, fixed = TRUE)
         for (drop.arg in c(TRUE, FALSE)) {
             expect_equal(input[drop = drop.arg], input)
-    }
+        }
     }
 })
 
@@ -97,7 +97,7 @@ expectedSingleTable <- function(tab, ind, drop = NULL) {
         all.inds.single <- any(lengths(ind)[1:4] == 1L & !vapply(ind[1:4], isEmptyArg, logical(1L))) && !isFALSE(drop)
         attr(y, "questiontypes") <- c("NumberGrid", if (all.inds.single) "NumberMulti" else "NumberGrid")
     } else {
-    attr(y, "statistic") <- "Average"
+        attr(y, "statistic") <- "Average"
     }
     attr(y, "name") <- paste0("table.", paste0(dim(tab), collapse = "."))
     if (!is.array(y) && length(y) > 1L) {
@@ -129,7 +129,7 @@ expectedDoubleTable <- function(tab, ind, exact = NULL) {
             if (is.integer(ind[[5L]])) dimnames(tab)[[5L]][ind[[5L]]] else match.arg(ind[[5L]], dimnames(tab)[[5L]])
         }
     } else {
-    attr(y, "statistic") <- "Average"
+        attr(y, "statistic") <- "Average"
     }
     attr(y, "is.subscripted") <- !identical(dim(y), dim(tab)) ||
         !identical(dimnames(y), dimnames(tab)) ||
@@ -150,7 +150,6 @@ test_that("Check indices subscripted correctly", {
     }
 
     for (tab in subsettable.tables) {
-        attr(tab, "questiontypes") <- c("Text")
         n.dim <- length(dim(tab))
         n <- n.possible[1:n.dim]
         selected <- n.selected[1:n.dim]
@@ -223,7 +222,6 @@ test_that("Check entire dimension works when index is empty", {
         indexed.random.names[[as.character(ind.size)]][randomIndex(ind.size, length(size))]
     }
     for (tab in subsettable.tables) {
-        attr(tab, "questiontypes") <- c("Text")
         dims <- dim(tab)
         n.dim <- length(dims)
         if (n.dim == 1) # Single dim array not relevant here


### PR DESCRIPTION
In our bid to replace Q based table tests, I've added some missing test cases to cover off subscripting for q tables. There will be additional tests on the qlib side of things.